### PR TITLE
refactor: use css vars for syntax highlighting

### DIFF
--- a/src/core/styles/vt-doc-code.css
+++ b/src/core/styles/vt-doc-code.css
@@ -284,7 +284,7 @@
 .vt-doc .token.tag,
 .vt-doc .token.attr-name,
 .vt-doc .token.namespace {
-  color: var(--vt-code-attr);
+  color: var(--vt-code-attribute);
 }
 
 .vt-doc .token.function-name {


### PR DESCRIPTION
So it could be easier to configure and override by the theme users.