### PR TITLE
refactor(nav-bar): tiny adjustment for search button

### DIFF
--- a/src/vitepress/components/VPAlgoliaSearchBox.vue
+++ b/src/vitepress/components/VPAlgoliaSearchBox.vue
@@ -144,12 +144,24 @@ function getRelativePath(absoluteUrl: string) {
 }
 
 .DocSearch-Button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   margin: 0;
+  width: 48px;
+  height: 55px;
   background: transparent;
 }
 
 .DocSearch-Button:hover {
   background: transparent;
+}
+
+@media (min-width: 768px) {
+  .DocSearch-Button {
+    justify-content: flex-start;
+    width: 100%;
+  }
 }
 
 .DocSearch-Button .DocSearch-Search-Icon {
@@ -159,14 +171,14 @@ function getRelativePath(absoluteUrl: string) {
   width: 18px;
   height: 18px;
   position: relative;
-  margin-right: 10px;
 }
 
 @media (min-width: 768px) {
   .DocSearch-Button .DocSearch-Search-Icon {
+    top: 1px;
+    margin-right: 10px;
     width: 15px;
     height: 15px;
-    top: 1px;
   }
 }
 
@@ -194,6 +206,7 @@ function getRelativePath(absoluteUrl: string) {
 }
 
 .DocSearch-Button .DocSearch-Button-Key {
+  margin-top: 2px;
   border: 1px solid var(--vt-c-divider);
   border-right: none;
   border-radius: 4px 0 0 4px;


### PR DESCRIPTION
Adjust the search button slightly.

- In mobile view, place the icon center of the clickable box so it aligns better spacing with hamburger menu icon.
- In desktop view, align shortcut icon to the text and search icon.

Current:
<img width="504" alt="Screen Shot 2021-09-15 at 11 21 46" src="https://user-images.githubusercontent.com/3753672/133359840-915ca591-2687-401f-b75c-84fb7e06d7d4.png">

With this PR
<img width="649" alt="Screen Shot 2021-09-15 at 11 20 35" src="https://user-images.githubusercontent.com/3753672/133359848-1fe8a271-14c1-466b-860e-5e9582b4dbe8.png">
