### PR TITLE
fix: Get only the skiplink anchor hash

### DIFF
--- a/src/vitepress/components/VPSkipLink.vue
+++ b/src/vitepress/components/VPSkipLink.vue
@@ -12,7 +12,7 @@ watch(
 
 const focusOnTargetAnchor = ({ target }: Event) => {
   const el = document.querySelector(
-    (target as HTMLAnchorElement).href!
+    (target as HTMLAnchorElement).hash!
   ) as HTMLAnchorElement
 
   if (el) {


### PR DESCRIPTION
Changing from `href` to `hash` because the `href` is returning the complete URL, causing an error in the querySelector.