### PR TITLE
Fixed keyboard shortcut icon in searchbar

### DIFF
--- a/src/vitepress/components/VPNavBarSearch.vue
+++ b/src/vitepress/components/VPNavBarSearch.vue
@@ -12,6 +12,7 @@ const VPAlgoliaSearchBox = defineAsyncComponent(
 // payload), we delay initializing it until the user has actually clicked or
 // hit the hotkey to invoke it
 const loaded = ref(false)
+const isMacOs = ref(false)
 
 onMounted(() => {
   const handleSearchHotKey = (e: KeyboardEvent) => {
@@ -26,6 +27,10 @@ onMounted(() => {
   }
   window.addEventListener('keydown', handleSearchHotKey)
   onUnmounted(remove)
+
+  const platform =
+    (navigator as any)?.userAgentData?.platform || navigator?.platform || ''
+  isMacOs.value = platform.toLowerCase()?.includes('mac') || false
 })
 
 function load() {
@@ -63,7 +68,17 @@ function load() {
           <span class="DocSearch-Button-Placeholder">Search</span>
         </span>
         <span class="DocSearch-Button-Keys">
-          <span class="DocSearch-Button-Key">⌘</span>
+          <span class="DocSearch-Button-Key" v-if="isMacOs">⌘</span>
+          <span class="DocSearch-Button-Key" v-else>
+            <svg width="15" height="15" class="DocSearch-Control-Key-Icon">
+              <path
+                d="M4.505 4.496h2M5.505 5.496v5M8.216 4.496l.055 5.993M10 7.5c.333.333.5.667.5 1v2M12.326 4.5v5.996M8.384 4.496c1.674 0 2.116 0 2.116 1.5s-.442 1.5-2.116 1.5M3.205 9.303c-.09.448-.277 1.21-1.241 1.203C1 10.5.5 9.513.5 8V7c0-1.57.5-2.5 1.464-2.494.964.006 1.134.598 1.24 1.342M12.553 10.5h1.953"
+                stroke-width="1.2"
+                stroke="currentColor"
+                fill="none"
+                stroke-linecap="square"
+              ></path></svg
+          ></span>
           <span class="DocSearch-Button-Key">K</span>
         </span>
       </button>


### PR DESCRIPTION
Hi, this small PR fixes some minor issues with the appearance of the search bar that you can find in the [staging VueJS documentation](https://staging.vuejs.org/).
If you open that page using your browser on either Windows or any Linux-based distro, you will see that it shows the keyboard shortcut `⌘+K`, which is presumably correct only on MacOS. With this pull request, the documentation website will check whether current user is using Windows/Linux or MacOS. In the first case, it will show an appropriate keyboard shortcut hint (`CTRL+K`). If user is on MacOS, it will keep using `⌘+K`.

Note: the svg embedded in the `v-else` branch is the same icon that Algolia/Docsearch will use once the popup has been shown at least once. In this way we do not end up with weird icon changes after that the search popup has been opened.