### PR TITLE
fix: remove hardcoded repository from edit link

### DIFF
--- a/src/vitepress/components/VPContentDoc.vue
+++ b/src/vitepress/components/VPContentDoc.vue
@@ -14,7 +14,7 @@ const hashMatch = /#(\w+)$/
 const repoUrl = computed(() => {
   const repo = theme.value.editLink?.repo || 'vuejs/docs'
   const branch = repo.match(hashMatch)?.[1] || 'main'
-  return `https://github.com/${repo}/edit/${branch}/src/${page.value.relativePath}`
+  return `https://github.com/${repo.split('#')[0]}/edit/${branch}/src/${page.value.relativePath}`
 })
 
 const pageClass = computed(() => {

--- a/src/vitepress/components/VPContentDoc.vue
+++ b/src/vitepress/components/VPContentDoc.vue
@@ -14,7 +14,7 @@ const hashMatch = /#(\w+)$/
 const repoUrl = computed(() => {
   const repo = theme.value.editLink?.repo || 'vuejs/docs'
   const branch = repo.match(hashMatch)?.[1] || 'main'
-  return `https://github.com/vuejs/docs/edit/${branch}/src/${page.value.relativePath}`
+  return `https://github.com/${repo}/edit/${branch}/src/${page.value.relativePath}`
 })
 
 const pageClass = computed(() => {


### PR DESCRIPTION
This PR fixes the hardcoded link for the "edit this page" feature.