### PR TITLE
fix: error when algolia does not exist

### DIFF
--- a/src/vitepress/components/VPNavBarSearch.vue
+++ b/src/vitepress/components/VPNavBarSearch.vue
@@ -15,6 +15,8 @@ const loaded = ref(false)
 const metaKey = ref()
 
 onMounted(() => {
+  if (!theme.value.algolia) return
+
   // meta key detect (same logic as in @docsearch/js)
   metaKey.value.textContent = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)
     ? '⌘'


### PR DESCRIPTION
Error when algolia does not exist: `Cannot set properties of undefined (setting 'textContent') in VPNavBarSearch.vue:21`.