### PR TITLE
feat: adding VTCodeGroup component to the @vue/theme (#46)

### DIFF
--- a/src/core/components/VTCodeGroup.vue
+++ b/src/core/components/VTCodeGroup.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import { VTCodeGroupTab } from '..';
+import { useSlots, ref } from 'vue'
+const activeTabIndex = ref(0)
+const children = useSlots().default?.()
+const tabs = children?.filter(({ type }) => type === VTCodeGroupTab)
+</script>
+
+<template>
+  <div class="vt-code-group">
+    <div class="vt-code-group-tabs">
+      <div
+        v-for="tab, idx in tabs"
+        @click="activeTabIndex = idx"
+        class="vt-code-group-tab"
+        :class="{
+          'vt-code-group-tab-active': activeTabIndex === idx
+        }"
+      >{{ tab.props?.label }}</div>
+    </div>
+    <div class="vt-code-group-contents">
+      <component
+        v-for="tab, idx in tabs"
+        v-show="activeTabIndex === idx"
+        :is="tab"
+        :active="activeTabIndex === idx"
+      />
+    </div>
+  </div>
+</template>

--- a/src/core/components/VTCodeGroupTab.vue
+++ b/src/core/components/VTCodeGroupTab.vue
@@ -1,0 +1,5 @@
+<template>
+<div class="vt-code-group-content">
+  <slot/>
+</div>
+</template>

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,6 +34,8 @@ export { default as VTIconYouTube } from './components/icons/VTIconYouTube.vue'
 export { default as VTIconEdit } from './components/icons/VTIconEdit.vue'
 
 export { default as VTBackdrop } from './components/VTBackdrop.vue'
+export { default as VTCodeGroup } from './components/VTCodeGroup.vue'
+export { default as VTCodeGroupTab } from './components/VTCodeGroupTab.vue'
 export { default as VTFlyout } from './components/VTFlyout.vue'
 export { default as VTHamburger } from './components/VTHamburger.vue'
 export { default as VTLink } from './components/VTLink.vue'

--- a/src/core/styles/index.css
+++ b/src/core/styles/index.css
@@ -2,6 +2,7 @@
 @import './variables.css';
 @import './base.css';
 @import './vt-backdrop.css';
+@import './vt-code-group.css';
 @import './vt-doc-base.css';
 @import './vt-doc-code.css';
 @import './vt-doc-custom-blocks.css';

--- a/src/core/styles/vt-code-group.css
+++ b/src/core/styles/vt-code-group.css
@@ -1,0 +1,73 @@
+.vt-code-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.vt-code-group-contents .vt-code-group-content div[class*='language-'] {
+  margin-top: 0;
+  border-top-left-radius: 0;
+}
+
+.vt-code-group-tabs {
+  display: flex;
+  overflow: auto;
+}
+
+.vt-code-group-tab {
+  white-space: pre;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--vt-c-text-inverse-1);
+  background: #292d3ef0;
+  border-bottom-color: rgba(255,255,255,0.3);
+  padding: 6px 24px;
+  border-width: 2px;
+  border-style: solid;
+  border-top: transparent;
+  border-right: transparent;
+  border-left: transparent;
+  cursor: pointer;
+  transition: border, background-color .2s;
+    transition-property: border, background-color;
+    transition-duration: 0.2s, 0.2s;
+    transition-timing-function: ease, ease;
+    transition-delay: 0s, 0s;
+}
+
+.vt-code-group-tab.vt-code-group-tab-active {
+  background: #292d3e;
+  border-bottom: 2px solid var(--vt-c-brand);
+}
+
+.vt-code-group-tab:first-child {
+  border-top-left-radius: 8px;
+}
+
+.vt-code-group-tab:last-child {
+  border-top-right-radius: 8px;
+}
+
+.dark .vt-code-group-tab {
+  color: var(--vt-c-text-1);
+}
+
+.dark .vt-code-group-tab:not(.vt-code-group-tab-active) {
+  border-bottom: 2px solid rgba(255,255,255,.2);
+  background: var(--vt-c-black-mute);
+}
+
+.dark .vt-code-group-tab.vt-code-group-tab-active {
+  background: var(--vt-c-black-soft);
+}
+
+@media (max-width: 639px) {
+  .vt-code-group-tabs {
+    margin: 0 -24px;
+  }
+
+  .vt-code-group-tab, .vt-code-group-tab:first-child, .vt-code-group-tab:last-child {
+    flex-grow: 1;
+    border-radius: 0;
+  }
+}


### PR DESCRIPTION
Resolves #46 

Adds a VTCodeGroup component to replace https://github.com/vuejs/docs/blob/main/src/guide/scaling-up/TestingApiSwitcher.vue

Also @kiaking it fixes the mobile responsive issues you saw with the original implementation. To test it, I replaced the custom component I pasted above locally. I was looking for a way to demo/test out the component in this repo. Is there any infra for that?

https://user-images.githubusercontent.com/2801156/155276939-631c87b0-94c8-4038-afd8-f52d8662cd3b.mov