### PR TITLE
fix: Make branch name regex more compatible

### DIFF
--- a/src/vitepress/components/VPContentDoc.vue
+++ b/src/vitepress/components/VPContentDoc.vue
@@ -9,7 +9,7 @@ import { VTLink, VTIconEdit } from '../../core'
 
 const { page, frontmatter, theme } = useData<Config>()
 
-const hashMatch = /#(\w+)$/
+const hashMatch = /#([\w\.\-\/]+)$/
 
 const repoUrl = computed(() => {
   const repo = theme.value.editLink?.repo || 'vuejs/docs'


### PR DESCRIPTION
This PR fixes compatibility issues with branch name matching for the "edit this page" feature.

**Before** 
<img width="440" alt="image" src="https://user-images.githubusercontent.com/1472352/156507833-66dd6ec2-a0ca-4748-8b61-64ee2b733f46.png">

**After**
<img width="494" alt="image" src="https://user-images.githubusercontent.com/1472352/156507753-252d0053-b191-4a42-ac21-4491e105125a.png">
