### PR TITLE
fix: Error when themeConfig.algolia==undefined

### DIFF
--- a/src/vitepress/components/VPNavBarSearch.vue
+++ b/src/vitepress/components/VPNavBarSearch.vue
@@ -15,6 +15,10 @@ const loaded = ref(false)
 const metaKey = ref()
 
 onMounted(() => {
+  if (!metaKey.value) {
+    return
+  }
+
   // meta key detect (same logic as in @docsearch/js)
   metaKey.value.textContent = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)
     ? '⌘'


### PR DESCRIPTION
当themeConfig.algolia==undefined时，VPNavBarSearch.vue报错：Cannot set properties of undefined.

the error that "Cannot set properties of undefined" in VPNavBarSearch.vue when themeConfig.algolia==undefined
(i am sorry for my English ^ ^) 

![截屏2022-03-04 11 30 50](https://user-images.githubusercontent.com/15799030/156695461-94c90a9d-aca6-4b34-9690-7731f7b9f518.png)

