### PR TITLE
remove `a` style of `custom-block` class

### DIFF
--- a/src/core/styles/vt-doc-custom-blocks.css
+++ b/src/core/styles/vt-doc-custom-blocks.css
@@ -79,8 +79,3 @@
 .dark .vt-doc .custom-block :not(pre) > code {
   background-color: rgba(0, 0, 0, 0.2);
 }
-
-.vt-doc .custom-block.danger a,
-.vt-doc .custom-block.warning a {
-  color: var(--vt-c-text-code);
-}


### PR DESCRIPTION
When I read the documentation for the new version of Vue.js, I noticed an unusual CSS style:

<img width="757" alt="image" src="https://user-images.githubusercontent.com/10683193/164192192-216966c8-f472-4742-8b41-785494e2d9c9.png">

You can see the address of the documentation [here](https://vuejs.org/guide/essentials/conditional.html#v-if-with-v-for).

As indicated by the text highlighted in the red box above, this style guide is supposed to be a link, but it is the same color as the code (blue), not green elsewhere on the page.

I think all links should be green.

I looked at the Vue.js official documentation repository and found that it used the theme of this repository, and then located the CSS that was in question.

When I removed it (like this modification), it went back to normal:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/10683193/164192752-0d2c1d8d-ec4a-4ff1-a01b-be2fc3f1d80f.png">

I think this change is necessary because the green color tells the reader "Oh, this is a link, I need to click on it and see what's written on the other page".