### PR TITLE
Fix active element for side navigation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@docsearch/css': ^3.0.0-alpha.41

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 specifiers:
   '@docsearch/css': ^3.0.0-alpha.41

--- a/src/vitepress/composables/outline.ts
+++ b/src/vitepress/composables/outline.ts
@@ -60,7 +60,9 @@ export function useActiveAnchor(
     const anchors = [].slice
       .call(document.querySelectorAll('.content .header-anchor'))
       .filter((anchor: HTMLAnchorElement) =>
-        links.some((link) => link.hash === anchor.hash)
+        links.some(
+          (link) => link.hash === anchor.hash && anchor.offsetParent !== null
+        )
       ) as HTMLAnchorElement[]
 
     // page bottom - highlight last one


### PR DESCRIPTION
# This PR fixes: vuejs/docs#1687

## The Issue
When scrolling through the pages I noticed the side navigation not setting the active visible element correctly.
After looking through the logic of setting active element I noticed that it gets all anchors on the page rather than those that are visible (not `display: none`).

## The reason

When it was getting all anchors the `activateLink` function couldn't really calculate which was the active element since `nextAnchor` was `display: none` and it couldn't get its offetTop since offsetTop for hidden elements is `null` ([offsetTop docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop#browser_compatibility)) , this way it was setting the next active one to be the hidden one rather than what is currently visible. 

![image](https://user-images.githubusercontent.com/18427030/165157315-1292fc3f-3e3c-4e82-887f-e9dbce08ed1d.png)
![image](https://user-images.githubusercontent.com/18427030/165157609-b194406a-b1c7-46fe-b600-a8b0960aab71.png)


## The solution
When properly filtering the anchors to get only those that are visible, now it can properly calculate whether an element is active.
