### PR TITLE
fix: avoid setting margin-top for code samples in an edge case

### DIFF
--- a/src/core/styles/vt-doc-code.css
+++ b/src/core/styles/vt-doc-code.css
@@ -53,7 +53,7 @@
 
 .vt-doc div[class*='language-'] + div[class*='language-'],
 .vt-doc div[class$='-api'] + div[class*='language-'],
-.vt-doc div[class*='language-'] + div[class$='-api'] > div[class*='language-'] {
+.vt-doc div[class*='language-'] + div[class$='-api'] > div[class*='language-']:first-child {
   margin-top: -16px;
 }
 


### PR DESCRIPTION
The selector for setting a negative `margin-top` is intended to handle consecutive code samples. However, the part of the selector intended to handle samples nested inside `class="options-api"` or `class="composition-api"` is currently matching all code samples, when it should just be matching those at the start.

I've added `:first-child` so that other code samples are not impacted.

In the current Vue 3 docs there is only one place where this makes a difference. It's in <https://vuejs.org/guide/components/events.html>, when viewed in Options API mode.

**Before (see red arrow):**

![image](https://user-images.githubusercontent.com/65301168/174308388-170b750a-9613-44bf-adb9-47b4b54d1d86.png)

**After:**

![image](https://user-images.githubusercontent.com/65301168/174308629-3db3e252-aa28-4cb2-94e7-b6e6dd309e64.png)