### PR TITLE
Support i18n messages

### DIFF
--- a/demo/.vitepress/config.js
+++ b/demo/.vitepress/config.js
@@ -349,48 +349,49 @@ module.exports = (async () => {
             ]
           }
         ]
-      },
-
-      messages: {
-        // basic-level
-        search: 'Search',
-        previous: 'Previous',
-        next: 'Next',
-        menu: 'Menu',
-        appearance: 'Appearance',
-        meta: 'Meta',
-
-        // block-level
-        pageNotFound: 'Page Not Found',
-        tableOfContents: 'Table of Contents for current page',
-        mainNavigation: 'Main Navigation',
-        mobileNavigation: 'Mobile Navigation',
-        sidebarNavigation: 'Sidebar Navigation',
-
-        // sentence-level
-        announcer: {
-          before: '',
-          after: ' has loaded'
-        },
-        footerLicense: {
-          before: 'Released under the ',
-          after: '.'
-        },
-        deadLinkFound: {
-          before: 'You found a dead link: ',
-          after: ''
-        },
-        deadLinkReport: {
-          before: 'Please ',
-          content: 'let us know',
-          after: ' so we can fix it.'
-        },
-
-        // action-level
-        toggleDarkMode: 'Toggle Dark Mode',
-        returnToTop: 'Return to top',
-        skipToContent: 'Skip to content'
       }
+
+      // // For i18n translation messages
+      // messages: {
+      //   // basic-level
+      //   search: 'Search',
+      //   previous: 'Previous',
+      //   next: 'Next',
+      //   menu: 'Menu',
+      //   appearance: 'Appearance',
+      //   meta: 'Meta',
+      //
+      //   // block-level
+      //   pageNotFound: 'Page Not Found',
+      //   tableOfContents: 'Table of Contents for current page',
+      //   mainNavigation: 'Main Navigation',
+      //   mobileNavigation: 'Mobile Navigation',
+      //   sidebarNavigation: 'Sidebar Navigation',
+      //
+      //   // sentence-level
+      //   announcer: {
+      //     before: '',
+      //     after: ' has loaded'
+      //   },
+      //   footerLicense: {
+      //     before: 'Released under the ',
+      //     after: '.'
+      //   },
+      //   deadLinkFound: {
+      //     before: 'You found a dead link: ',
+      //     after: ''
+      //   },
+      //   deadLinkReport: {
+      //     before: 'Please ',
+      //     content: 'let us know',
+      //     after: ' so we can fix it.'
+      //   },
+      //
+      //   // action-level
+      //   toggleDarkMode: 'Toggle Dark Mode',
+      //   returnToTop: 'Return to top',
+      //   skipToContent: 'Skip to content'
+      // }
     }
   }
 })()

--- a/demo/.vitepress/config.js
+++ b/demo/.vitepress/config.js
@@ -352,31 +352,14 @@ module.exports = (async () => {
       }
 
       // // For i18n translation messages
-      // messages: {
-      //   // basic-level
+      // i18n: {
       //   search: 'Search',
+      //   menu: 'Menu',
+      //   returnToTop: 'Return to top',
+      //   appearance: 'Appearance',
       //   previous: 'Previous',
       //   next: 'Next',
-      //   menu: 'Menu',
-      //   appearance: 'Appearance',
-      //   meta: 'Meta',
-      //
-      //   // block-level
       //   pageNotFound: 'Page Not Found',
-      //   tableOfContents: 'Table of Contents for current page',
-      //   mainNavigation: 'Main Navigation',
-      //   mobileNavigation: 'Mobile Navigation',
-      //   sidebarNavigation: 'Sidebar Navigation',
-      //
-      //   // sentence-level
-      //   announcer: {
-      //     before: '',
-      //     after: ' has loaded'
-      //   },
-      //   footerLicense: {
-      //     before: 'Released under the ',
-      //     after: '.'
-      //   },
       //   deadLinkFound: {
       //     before: 'You found a dead link: ',
       //     after: ''
@@ -386,11 +369,22 @@ module.exports = (async () => {
       //     content: 'let us know',
       //     after: ' so we can fix it.'
       //   },
-      //
-      //   // action-level
-      //   toggleDarkMode: 'Toggle Dark Mode',
-      //   returnToTop: 'Return to top',
-      //   skipToContent: 'Skip to content'
+      //   footerLicense: {
+      //     before: 'Released under the ',
+      //     after: '.'
+      //   }
+
+      //   // aria labels
+      //   ariaAnnouncer: {
+      //     before: '',
+      //     after: ' has loaded'
+      //   },
+      //   ariaDarkMode: 'Toggle Dark Mode',
+      //   ariaSkip: 'Skip to content',
+      //   ariaTOC: 'Table of Contents for current page',
+      //   ariaMainNav: 'Main Navigation',
+      //   ariaMobileNav: 'Mobile Navigation',
+      //   ariaSidebarNav: 'Sidebar Navigation',
       // }
     }
   }

--- a/demo/.vitepress/config.js
+++ b/demo/.vitepress/config.js
@@ -1,6 +1,9 @@
 const getBase = require('../../src/vitepress/config/baseConfig')
 const path = require('path')
 
+/**
+ * @type {() => Promise<import('vitepress').UserConfig>}
+ */
 module.exports = (async () => {
   const base = await getBase()
   return {
@@ -346,6 +349,47 @@ module.exports = (async () => {
             ]
           }
         ]
+      },
+
+      messages: {
+        // basic-level
+        search: 'Search',
+        previous: 'Previous',
+        next: 'Next',
+        menu: 'Menu',
+        appearance: 'Appearance',
+        meta: 'Meta',
+
+        // block-level
+        pageNotFound: 'Page Not Found',
+        tableOfContents: 'Table of Contents for current page',
+        mainNavigation: 'Main Navigation',
+        mobileNavigation: 'Mobile Navigation',
+        sidebarNavigation: 'Sidebar Navigation',
+
+        // sentence-level
+        announcer: {
+          before: '',
+          after: ' has loaded'
+        },
+        footerLicense: {
+          before: 'Released under the ',
+          after: '.'
+        },
+        deadLinkFound: {
+          before: 'You found a dead link: ',
+          after: ''
+        },
+        deadLinkReport: {
+          before: 'Please ',
+          content: 'let us know',
+          after: ' so we can fix it.'
+        },
+
+        // action-level
+        toggleDarkMode: 'Toggle Dark Mode',
+        returnToTop: 'Return to top',
+        skipToContent: 'Skip to content'
       }
     }
   }

--- a/src/core/components/VTHamburger.vue
+++ b/src/core/components/VTHamburger.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
-import { useData } from 'vitepress'
-const { theme } = useData()
+import { useConfig } from '../../vitepress/composables/config'
+
+const { config } = useConfig()
+
 defineProps<{
   active: boolean
 }>()
@@ -11,10 +13,7 @@ defineProps<{
     type="button"
     class="vt-hamburger"
     :class="{ 'is-active': active }"
-    :aria-label="
-      theme?.messages?.mobileNavigation ??
-      'Mobile navigation'
-    "
+    :aria-label="config.i18n?.ariaMobileNav ?? 'Mobile navigation'"
     :aria-expanded="active"
     aria-controls="VPNavScreen"
   >

--- a/src/core/components/VTHamburger.vue
+++ b/src/core/components/VTHamburger.vue
@@ -11,7 +11,10 @@ defineProps<{
     type="button"
     class="vt-hamburger"
     :class="{ 'is-active': active }"
-    :aria-label="theme.messages.mobileNavigation"
+    :aria-label="
+      theme?.messages?.mobileNavigation ??
+      'Mobile navigation'
+    "
     :aria-expanded="active"
     aria-controls="VPNavScreen"
   >

--- a/src/core/components/VTHamburger.vue
+++ b/src/core/components/VTHamburger.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { useData } from 'vitepress'
+const { theme } = useData()
 defineProps<{
   active: boolean
 }>()
@@ -9,7 +11,7 @@ defineProps<{
     type="button"
     class="vt-hamburger"
     :class="{ 'is-active': active }"
-    aria-label="mobile navigation"
+    :aria-label="theme.messages.mobileNavigation"
     :aria-expanded="active"
     aria-controls="VPNavScreen"
   >

--- a/src/core/components/VTSwitchAppearance.vue
+++ b/src/core/components/VTSwitchAppearance.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
-import { useData } from 'vitepress'
 import VTSwitch from './VTSwitch.vue'
 import VTIconSun from './icons/VTIconSun.vue'
 import VTIconMoon from './icons/VTIconMoon.vue'
+import { useConfig } from '../../vitepress/composables/config'
 
-const { theme } = useData()
+const { config } = useConfig()
 
 const storageKey = 'vue-theme-appearance'
 const toggle = typeof localStorage !== 'undefined' ? useAppearance() : () => {}
@@ -44,10 +44,7 @@ function useAppearance() {
 <template>
   <VTSwitch
     class="vt-switch-appearance"
-    :aria-label="
-      theme?.messages?.toggleDarkMode ??
-      'Toggle dark mode'
-    "
+    :aria-label="config.i18n?.ariaDarkMode ?? 'Toggle dark mode'"
     @click="toggle"
   >
     <VTIconSun class="vt-switch-appearance-sun" />

--- a/src/core/components/VTSwitchAppearance.vue
+++ b/src/core/components/VTSwitchAppearance.vue
@@ -44,7 +44,10 @@ function useAppearance() {
 <template>
   <VTSwitch
     class="vt-switch-appearance"
-    :aria-label="theme.messages.toggleDarkMode"
+    :aria-label="
+      theme?.messages?.toggleDarkMode ??
+      'Toggle dark mode'
+    "
     @click="toggle"
   >
     <VTIconSun class="vt-switch-appearance-sun" />

--- a/src/core/components/VTSwitchAppearance.vue
+++ b/src/core/components/VTSwitchAppearance.vue
@@ -1,7 +1,10 @@
 <script lang="ts" setup>
+import { useData } from 'vitepress'
 import VTSwitch from './VTSwitch.vue'
 import VTIconSun from './icons/VTIconSun.vue'
 import VTIconMoon from './icons/VTIconMoon.vue'
+
+const { theme } = useData()
 
 const storageKey = 'vue-theme-appearance'
 const toggle = typeof localStorage !== 'undefined' ? useAppearance() : () => {}
@@ -41,7 +44,7 @@ function useAppearance() {
 <template>
   <VTSwitch
     class="vt-switch-appearance"
-    aria-label="toggle dark mode"
+    :aria-label="theme.messages.toggleDarkMode"
     @click="toggle"
   >
     <VTIconSun class="vt-switch-appearance-sun" />

--- a/src/core/types/menu.ts
+++ b/src/core/types/menu.ts
@@ -6,7 +6,7 @@ export interface MenuItemWithLink {
 }
 
 export interface MenuItemWithChildren {
-  text: string
+  text?: string
   items: MenuItemChild[]
 }
 

--- a/src/vitepress/components/VPAlgoliaSearchBox.vue
+++ b/src/vitepress/components/VPAlgoliaSearchBox.vue
@@ -1,16 +1,22 @@
 <script setup lang="ts">
 import docsearch from '@docsearch/js'
-import { useRoute, useRouter, useData } from 'vitepress'
+import { useRoute, useRouter } from 'vitepress'
 import { onMounted } from 'vue'
-import { DocSearchHit } from '@docsearch/react/dist/esm/types'
-import { AlgoliaSearchOptions } from '../config'
+import { useConfig } from '../composables/config'
+import type { AlgoliaSearchOptions } from '../config'
 
-const { theme } = useData()
+// partial type only containing what we need
+interface DocSearchHit {
+  url: string
+}
+
+const { config } = useConfig()
 const route = useRoute()
 const router = useRouter()
 
 onMounted(() => {
-  initialize(theme.value.algolia)
+  // this component will only render if user has configured algolia
+  initialize(config.value.algolia!)
   setTimeout(poll, 16)
 })
 

--- a/src/vitepress/components/VPAnnouncer.vue
+++ b/src/vitepress/components/VPAnnouncer.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
 import { useData } from 'vitepress'
 
-const { page } = useData()
+const { page, theme } = useData()
 </script>
 
 <template>
-  <div class="visually-hidden" aria-live="polite">{{ page.title }} has loaded</div>
+  <div class="visually-hidden" aria-live="polite">{{
+    theme.messages.announcer.before
+  }}{{ page.title }}{{
+    theme.messages.announcer.after
+  }}</div>
 </template>

--- a/src/vitepress/components/VPAnnouncer.vue
+++ b/src/vitepress/components/VPAnnouncer.vue
@@ -1,15 +1,15 @@
 <script lang="ts" setup>
 import { useData } from 'vitepress'
+import { useConfig } from '../composables/config'
+import type { Config } from '../config'
 
-const { page, theme } = useData()
+const { page } = useData<Config>()
+const { config } = useConfig()
 </script>
 
 <template>
-  <div class="visually-hidden" aria-live="polite">{{
-    theme?.messages?.announcer?.before ??
-    ''
-  }}{{ page.title }}{{
-    theme?.messages?.announcer?.after ??
-    ' has loaded'
-  }}</div>
+  <div class="visually-hidden" aria-live="polite">
+    {{ config.i18n?.ariaAnnouner?.before ?? '' }}{{ page.title
+    }}{{ config.i18n?.ariaAnnouner?.after ?? ' has loaded' }}
+  </div>
 </template>

--- a/src/vitepress/components/VPAnnouncer.vue
+++ b/src/vitepress/components/VPAnnouncer.vue
@@ -6,8 +6,10 @@ const { page, theme } = useData()
 
 <template>
   <div class="visually-hidden" aria-live="polite">{{
-    theme.messages.announcer.before
+    theme?.messages?.announcer?.before ??
+    ''
   }}{{ page.title }}{{
-    theme.messages.announcer.after
+    theme?.messages?.announcer?.after ??
+    ' has loaded'
   }}</div>
 </template>

--- a/src/vitepress/components/VPCarbonAds.vue
+++ b/src/vitepress/components/VPCarbonAds.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
-import { useData } from 'vitepress'
 import { ref, onMounted, watch } from 'vue'
+import { useConfig } from '../composables/config'
 
-const { theme } = useData()
-const carbonOptions = theme.value.carbonAds
+const { config } = useConfig()
+// this component only loads when user has configured carbonAds
+const carbonOptions = config.value.carbonAds!
 const container = ref()
 const isWide = useMediaQuery('(min-width: 1280px)')
 

--- a/src/vitepress/components/VPContentDoc.vue
+++ b/src/vitepress/components/VPContentDoc.vue
@@ -4,17 +4,20 @@ import { useData } from 'vitepress'
 import VPContentDocOutline from './VPContentDocOutline.vue'
 import VPContentDocFooter from './VPContentDocFooter.vue'
 import VPCarbonAds from './VPCarbonAds.vue'
-import type { Config } from '../config'
 import { VTLink, VTIconEdit } from '../../core'
+import { useConfig } from '../composables/config'
 
-const { page, frontmatter, theme } = useData<Config>()
+const { page, frontmatter } = useData()
+const { config } = useConfig()
 
 const hashMatch = /#(\w+)$/
 
 const repoUrl = computed(() => {
-  const repo = theme.value.editLink?.repo || 'vuejs/docs'
+  const repo = config.value.editLink?.repo || 'vuejs/docs'
   const branch = repo.match(hashMatch)?.[1] || 'main'
-  return `https://github.com/${repo.split('#')[0]}/edit/${branch}/src/${page.value.relativePath}`
+  return `https://github.com/${repo.split('#')[0]}/edit/${branch}/src/${
+    page.value.relativePath
+  }`
 })
 
 const pageClass = computed(() => {
@@ -36,7 +39,7 @@ const pageClass = computed(() => {
             v-if="page.headers && frontmatter.outline !== false"
           />
           <slot name="aside-mid" />
-          <VPCarbonAds v-if="theme.carbonAds && frontmatter.ads !== false" />
+          <VPCarbonAds v-if="config.carbonAds && frontmatter.ads !== false" />
           <slot name="aside-bottom" />
         </div>
       </div>
@@ -46,10 +49,12 @@ const pageClass = computed(() => {
           <Content class="vt-doc" :class="pageClass" />
           <p
             class="edit-link"
-            v-if="theme.editLink && frontmatter.editLink !== false"
+            v-if="config.editLink && frontmatter.editLink !== false"
           >
             <VTIconEdit class="vt-icon" />
-            <VTLink :href="repoUrl" :no-icon="true">{{ theme.editLink.text }}</VTLink>
+            <VTLink :href="repoUrl" :no-icon="true">{{
+              config.editLink.text
+            }}</VTLink>
           </p>
         </main>
         <slot name="content-bottom" />

--- a/src/vitepress/components/VPContentDocFooter.vue
+++ b/src/vitepress/components/VPContentDocFooter.vue
@@ -9,11 +9,13 @@ import {
   VTIconChevronRight,
   MenuItemWithLink
 } from '../../core'
+import { useConfig } from '../composables/config'
 
-const { page, theme } = useData()
+const { page } = useData()
+const { config } = useConfig()
 
 const links = computed(() => {
-  const sidebar = getSidebar(theme.value.sidebar, page.value.relativePath)
+  const sidebar = getSidebar(config.value.sidebar, page.value.relativePath)
   const candidates = getFlatSideBarLinks(sidebar)
   const index = candidates.findIndex((link) =>
     isActive(page.value.relativePath, link.link)
@@ -37,16 +39,24 @@ function getFlatSideBarLinks(sidebar: SidebarGroup[]): MenuItemWithLink[] {
 
 <template>
   <footer v-if="links.prev || links.next" class="VPContentDocFooter">
-    <a v-if="links.prev" class="prev-link" :href="normalizeLink(links.prev.link)">
+    <a
+      v-if="links.prev"
+      class="prev-link"
+      :href="normalizeLink(links.prev.link)"
+    >
       <span class="desc">
         <VTIconChevronLeft class="vt-link-icon" />
-        {{ theme?.messages?.previous ?? 'Previous' }}
+        {{ config.i18n?.previous ?? 'Previous' }}
       </span>
       <span class="title">{{ links.prev.text }} </span>
     </a>
-    <a v-if="links.next" class="next-link" :href="normalizeLink(links.next.link)">
+    <a
+      v-if="links.next"
+      class="next-link"
+      :href="normalizeLink(links.next.link)"
+    >
       <span class="desc">
-        {{ theme?.messages?.next ?? 'Next' }}
+        {{ config.i18n?.next ?? 'Next' }}
         <VTIconChevronRight class="vt-link-icon" />
       </span>
       <span class="title">{{ links.next.text }}</span>

--- a/src/vitepress/components/VPContentDocFooter.vue
+++ b/src/vitepress/components/VPContentDocFooter.vue
@@ -37,22 +37,18 @@ function getFlatSideBarLinks(sidebar: SidebarGroup[]): MenuItemWithLink[] {
 
 <template>
   <footer v-if="links.prev || links.next" class="VPContentDocFooter">
-    <a
-      v-if="links.prev"
-      class="prev-link"
-      :href="normalizeLink(links.prev.link)"
-    >
-      <span class="desc"
-        ><VTIconChevronLeft class="vt-link-icon" /> Previous</span
-      >
+    <a v-if="links.prev" class="prev-link" :href="normalizeLink(links.prev.link)">
+      <span class="desc">
+        <VTIconChevronLeft class="vt-link-icon" />
+        {{ theme.messages.previous }}
+      </span>
       <span class="title">{{ links.prev.text }} </span>
     </a>
-    <a
-      v-if="links.next"
-      class="next-link"
-      :href="normalizeLink(links.next.link)"
-    >
-      <span class="desc">Next <VTIconChevronRight class="vt-link-icon" /></span>
+    <a v-if="links.next" class="next-link" :href="normalizeLink(links.next.link)">
+      <span class="desc">
+        {{ theme.messages.next }}
+        <VTIconChevronRight class="vt-link-icon" />
+      </span>
       <span class="title">{{ links.next.text }}</span>
     </a>
   </footer>

--- a/src/vitepress/components/VPContentDocFooter.vue
+++ b/src/vitepress/components/VPContentDocFooter.vue
@@ -40,13 +40,13 @@ function getFlatSideBarLinks(sidebar: SidebarGroup[]): MenuItemWithLink[] {
     <a v-if="links.prev" class="prev-link" :href="normalizeLink(links.prev.link)">
       <span class="desc">
         <VTIconChevronLeft class="vt-link-icon" />
-        {{ theme.messages.previous }}
+        {{ theme?.messages?.previous ?? 'Previous' }}
       </span>
       <span class="title">{{ links.prev.text }} </span>
     </a>
     <a v-if="links.next" class="next-link" :href="normalizeLink(links.next.link)">
       <span class="desc">
-        {{ theme.messages.next }}
+        {{ theme?.messages?.next ?? 'Next' }}
         <VTIconChevronRight class="vt-link-icon" />
       </span>
       <span class="title">{{ links.next.text }}</span>

--- a/src/vitepress/components/VPContentDocOutline.vue
+++ b/src/vitepress/components/VPContentDocOutline.vue
@@ -3,7 +3,7 @@ import { useData } from 'vitepress'
 import { resolveHeaders, useActiveAnchor } from '../composables/outline'
 import { computed, inject, ref } from 'vue'
 
-const { page, frontmatter } = useData()
+const { page, frontmatter, theme } = useData()
 const container = ref()
 const marker = ref()
 useActiveAnchor(container, marker)
@@ -30,7 +30,7 @@ const handleClick = ({ target: el }: Event) => {
     <div class="outline-title">On this page</div>
     <nav aria-labelledby="doc-outline-aria-label">
       <span id="doc-outline-aria-label" class="visually-hidden"
-        >Table of Contents for current page</span
+        >{{ theme.messages.tableOfContents }}</span
       >
       <ul class="root">
         <li

--- a/src/vitepress/components/VPContentDocOutline.vue
+++ b/src/vitepress/components/VPContentDocOutline.vue
@@ -29,9 +29,10 @@ const handleClick = ({ target: el }: Event) => {
     <div class="outline-marker" ref="marker" />
     <div class="outline-title">On this page</div>
     <nav aria-labelledby="doc-outline-aria-label">
-      <span id="doc-outline-aria-label" class="visually-hidden"
-        >{{ theme.messages.tableOfContents }}</span
-      >
+      <span id="doc-outline-aria-label" class="visually-hidden">{{
+        theme?.messages?.tableOfContents ??
+        'Table of Contents for current page'
+      }}</span>
       <ul class="root">
         <li
           v-for="{ text, link, children, hidden } in resolveHeaders(

--- a/src/vitepress/components/VPContentDocOutline.vue
+++ b/src/vitepress/components/VPContentDocOutline.vue
@@ -2,8 +2,10 @@
 import { useData } from 'vitepress'
 import { resolveHeaders, useActiveAnchor } from '../composables/outline'
 import { computed, inject, ref } from 'vue'
+import { useConfig } from '../composables/config'
 
-const { page, frontmatter, theme } = useData()
+const { page, frontmatter } = useData()
+const { config } = useConfig()
 const container = ref()
 const marker = ref()
 useActiveAnchor(container, marker)
@@ -30,8 +32,7 @@ const handleClick = ({ target: el }: Event) => {
     <div class="outline-title">On this page</div>
     <nav aria-labelledby="doc-outline-aria-label">
       <span id="doc-outline-aria-label" class="visually-hidden">{{
-        theme?.messages?.tableOfContents ??
-        'Table of Contents for current page'
+        config.i18n?.ariaToC ?? 'Table of Contents for current page'
       }}</span>
       <ul class="root">
         <li

--- a/src/vitepress/components/VPFooter.vue
+++ b/src/vitepress/components/VPFooter.vue
@@ -7,9 +7,13 @@ const { theme } = useData()
 
 <template>
   <div class="VPFooter">
-    <p v-if="theme.footer?.license" class="license">
-      Released under the <VTLink class="link" :href="theme.footer.license.link" no-icon>{{ theme.footer.license.text }}</VTLink>.
-    </p>
+    <p v-if="theme.footer?.license" class="license">{{
+      theme.messages.footerLicense.before
+    }}<VTLink class="link" :href="theme.footer.license.link" no-icon>{{
+      theme.footer.license.text
+    }}</VTLink>{{
+      theme.messages.footerLicense.after
+    }}</p>
 
     <p v-if="theme.footer?.copyright" class="copyright">
       {{ theme.footer.copyright }}

--- a/src/vitepress/components/VPFooter.vue
+++ b/src/vitepress/components/VPFooter.vue
@@ -8,11 +8,13 @@ const { theme } = useData()
 <template>
   <div class="VPFooter">
     <p v-if="theme.footer?.license" class="license">{{
-      theme.messages.footerLicense.before
+      theme?.messages?.footerLicense?.before ??
+      'Released under the '
     }}<VTLink class="link" :href="theme.footer.license.link" no-icon>{{
       theme.footer.license.text
     }}</VTLink>{{
-      theme.messages.footerLicense.after
+      theme?.messages?.footerLicense?.after ??
+      '.'
     }}</p>
 
     <p v-if="theme.footer?.copyright" class="copyright">

--- a/src/vitepress/components/VPFooter.vue
+++ b/src/vitepress/components/VPFooter.vue
@@ -1,24 +1,22 @@
 <script lang="ts" setup>
-import { useData } from 'vitepress'
 import { VTLink } from '../../core'
+import { useConfig } from '../composables/config'
 
-const { theme } = useData()
+const { config } = useConfig()
 </script>
 
 <template>
   <div class="VPFooter">
-    <p v-if="theme.footer?.license" class="license">{{
-      theme?.messages?.footerLicense?.before ??
-      'Released under the '
-    }}<VTLink class="link" :href="theme.footer.license.link" no-icon>{{
-      theme.footer.license.text
-    }}</VTLink>{{
-      theme?.messages?.footerLicense?.after ??
-      '.'
-    }}</p>
+    <p v-if="config.footer?.license" class="license">
+      {{ config.i18n?.footerLicense?.before ?? 'Released under the '
+      }}<VTLink class="link" :href="config.footer.license.link" no-icon>{{
+        config.footer.license.text
+      }}</VTLink
+      >{{ config.i18n?.footerLicense?.after ?? '.' }}
+    </p>
 
-    <p v-if="theme.footer?.copyright" class="copyright">
-      {{ theme.footer.copyright }}
+    <p v-if="config.footer?.copyright" class="copyright">
+      {{ config.footer.copyright }}
     </p>
   </div>
 </template>

--- a/src/vitepress/components/VPLocalNav.vue
+++ b/src/vitepress/components/VPLocalNav.vue
@@ -6,7 +6,7 @@ import { useData } from 'vitepress'
 defineProps<{ open: boolean }>()
 
 const { hasSidebar } = useSidebar()
-const { frontmatter } = useData()
+const { frontmatter, theme } = useData()
 
 function scrollToTop() {
   window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
@@ -22,7 +22,7 @@ function scrollToTop() {
       @click="$emit('open-menu')"
       >
       <VTIconAlignLeft class="menu-icon" />
-      <span class="menu-text">Menu</span>
+      <span class="menu-text">{{ theme.messages.menu }}</span>
     </button>
 
     <a
@@ -30,7 +30,7 @@ function scrollToTop() {
       class="top-link"
       href="#"
       @click="scrollToTop"
-      >Return to top</a
+      >{{ theme.messages.returnToTop }}</a
     >
   </div>
 </template>

--- a/src/vitepress/components/VPLocalNav.vue
+++ b/src/vitepress/components/VPLocalNav.vue
@@ -22,7 +22,9 @@ function scrollToTop() {
       @click="$emit('open-menu')"
       >
       <VTIconAlignLeft class="menu-icon" />
-      <span class="menu-text">{{ theme.messages.menu }}</span>
+      <span class="menu-text">{{
+        theme?.messages?.menu || 'Menu'
+      }}</span>
     </button>
 
     <a
@@ -30,8 +32,10 @@ function scrollToTop() {
       class="top-link"
       href="#"
       @click="scrollToTop"
-      >{{ theme.messages.returnToTop }}</a
-    >
+    >{{
+      theme?.messages?.returnToTop ??
+      'Return to top'
+    }}</a>
   </div>
 </template>
 

--- a/src/vitepress/components/VPLocalNav.vue
+++ b/src/vitepress/components/VPLocalNav.vue
@@ -2,11 +2,13 @@
 import { VTIconAlignLeft } from '../../core'
 import { useSidebar } from '../composables/sidebar'
 import { useData } from 'vitepress'
+import { useConfig } from '../composables/config'
 
 defineProps<{ open: boolean }>()
 
 const { hasSidebar } = useSidebar()
-const { frontmatter, theme } = useData()
+const { frontmatter } = useData()
+const { config } = useConfig()
 
 function scrollToTop() {
   window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
@@ -20,11 +22,9 @@ function scrollToTop() {
       :aria-expanded="open"
       aria-controls="VPSidebarNav"
       @click="$emit('open-menu')"
-      >
+    >
       <VTIconAlignLeft class="menu-icon" />
-      <span class="menu-text">{{
-        theme?.messages?.menu || 'Menu'
-      }}</span>
+      <span class="menu-text">{{ config.i18n?.menu || 'Menu' }}</span>
     </button>
 
     <a
@@ -32,10 +32,8 @@ function scrollToTop() {
       class="top-link"
       href="#"
       @click="scrollToTop"
-    >{{
-      theme?.messages?.returnToTop ??
-      'Return to top'
-    }}</a>
+      >{{ config.i18n?.returnToTop ?? 'Return to top' }}</a
+    >
   </div>
 </template>
 

--- a/src/vitepress/components/VPNavBarExtra.vue
+++ b/src/vitepress/components/VPNavBarExtra.vue
@@ -1,10 +1,8 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { useData } from 'vitepress'
 import { VTFlyout, VTSwitchAppearance, VTSocialLinks } from '../../core'
 import { useConfig } from '../composables/config'
 
-const { theme } = useData()
 const { config } = useConfig()
 
 const hasContent = computed(() => {
@@ -16,10 +14,9 @@ const hasContent = computed(() => {
   <VTFlyout v-if="hasContent" class="VPNavBarExtra" label="extra navigation">
     <div v-if="config.appearance" class="vt-menu-group">
       <div class="vt-menu-item item">
-        <p class="vt-menu-label">{{
-          theme?.messages?.appearance ??
-          'Appearance'
-        }}</p>
+        <p class="vt-menu-label">
+          {{ config.i18n?.appearance ?? 'Appearance' }}
+        </p>
         <div class="vt-menu-action action">
           <VTSwitchAppearance />
         </div>

--- a/src/vitepress/components/VPNavBarExtra.vue
+++ b/src/vitepress/components/VPNavBarExtra.vue
@@ -16,7 +16,10 @@ const hasContent = computed(() => {
   <VTFlyout v-if="hasContent" class="VPNavBarExtra" label="extra navigation">
     <div v-if="config.appearance" class="vt-menu-group">
       <div class="vt-menu-item item">
-        <p class="vt-menu-label">{{ theme.messages.appearance }}</p>
+        <p class="vt-menu-label">{{
+          theme?.messages?.appearance ??
+          'Appearance'
+        }}</p>
         <div class="vt-menu-action action">
           <VTSwitchAppearance />
         </div>

--- a/src/vitepress/components/VPNavBarExtra.vue
+++ b/src/vitepress/components/VPNavBarExtra.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
+import { useData } from 'vitepress'
 import { VTFlyout, VTSwitchAppearance, VTSocialLinks } from '../../core'
 import { useConfig } from '../composables/config'
 
+const { theme } = useData()
 const { config } = useConfig()
 
 const hasContent = computed(() => {
@@ -14,7 +16,7 @@ const hasContent = computed(() => {
   <VTFlyout v-if="hasContent" class="VPNavBarExtra" label="extra navigation">
     <div v-if="config.appearance" class="vt-menu-group">
       <div class="vt-menu-item item">
-        <p class="vt-menu-label">Appearance</p>
+        <p class="vt-menu-label">{{ theme.messages.appearance }}</p>
         <div class="vt-menu-action action">
           <VTSwitchAppearance />
         </div>

--- a/src/vitepress/components/VPNavBarMenu.vue
+++ b/src/vitepress/components/VPNavBarMenu.vue
@@ -1,18 +1,19 @@
 <script lang="ts" setup>
-import { useData } from 'vitepress'
 import { useConfig } from '../composables/config'
 import VPNavBarMenuLink from './VPNavBarMenuLink.vue'
 import VPNavBarMenuGroup from './VPNavBarMenuGroup.vue'
 
-const { theme } = useData()
 const { config } = useConfig()
 </script>
 
 <template>
-  <nav v-if="config.nav" aria-labelledby="main-nav-aria-label" class="VPNavBarMenu">
+  <nav
+    v-if="config.nav"
+    aria-labelledby="main-nav-aria-label"
+    class="VPNavBarMenu"
+  >
     <span id="main-nav-aria-label" class="visually-hidden">{{
-      theme?.messages?.mainNavigation ??
-      'Main Navigation'
+      config.i18n?.ariaMainNav ?? 'Main Navigation'
     }}</span>
     <template v-for="item in config.nav" :key="item.text">
       <VPNavBarMenuLink v-if="'link' in item" :item="item" />

--- a/src/vitepress/components/VPNavBarMenu.vue
+++ b/src/vitepress/components/VPNavBarMenu.vue
@@ -1,14 +1,18 @@
 <script lang="ts" setup>
+import { useData } from 'vitepress'
 import { useConfig } from '../composables/config'
 import VPNavBarMenuLink from './VPNavBarMenuLink.vue'
 import VPNavBarMenuGroup from './VPNavBarMenuGroup.vue'
 
+const { theme } = useData()
 const { config } = useConfig()
 </script>
 
 <template>
   <nav v-if="config.nav" aria-labelledby="main-nav-aria-label" class="VPNavBarMenu">
-    <span id="main-nav-aria-label" class="visually-hidden">Main Navigation</span>
+    <span id="main-nav-aria-label" class="visually-hidden">{{
+      theme.messages.mainNavigation
+    }}</span>
     <template v-for="item in config.nav" :key="item.text">
       <VPNavBarMenuLink v-if="'link' in item" :item="item" />
       <VPNavBarMenuGroup v-else :item="item" />

--- a/src/vitepress/components/VPNavBarMenu.vue
+++ b/src/vitepress/components/VPNavBarMenu.vue
@@ -11,7 +11,8 @@ const { config } = useConfig()
 <template>
   <nav v-if="config.nav" aria-labelledby="main-nav-aria-label" class="VPNavBarMenu">
     <span id="main-nav-aria-label" class="visually-hidden">{{
-      theme.messages.mainNavigation
+      theme?.messages?.mainNavigation ??
+      'Main Navigation'
     }}</span>
     <template v-for="item in config.nav" :key="item.text">
       <VPNavBarMenuLink v-if="'link' in item" :item="item" />

--- a/src/vitepress/components/VPNavBarSearch.vue
+++ b/src/vitepress/components/VPNavBarSearch.vue
@@ -49,7 +49,7 @@ function load() {
       <button
         type="button"
         class="DocSearch DocSearch-Button"
-        aria-label="Search"
+        :aria-label="theme.messages.search"
       >
         <span class="DocSearch-Button-Container">
           <svg
@@ -67,10 +67,10 @@ function load() {
               stroke-linejoin="round"
             ></path>
           </svg>
-          <span class="DocSearch-Button-Placeholder">Search</span>
+          <span class="DocSearch-Button-Placeholder">{{ theme.messages.search }}</span>
         </span>
         <span class="DocSearch-Button-Keys">
-          <span class="DocSearch-Button-Key" ref="metaKey">Meta</span>
+          <span class="DocSearch-Button-Key" ref="metaKey">{{ theme.messages.meta }}</span>
           <span class="DocSearch-Button-Key">K</span>
         </span>
       </button>

--- a/src/vitepress/components/VPNavBarSearch.vue
+++ b/src/vitepress/components/VPNavBarSearch.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
 import '@docsearch/css'
-import { useData } from 'vitepress'
 import { ref, defineAsyncComponent, onMounted, onUnmounted } from 'vue'
+import { useConfig } from '../composables/config'
 
-const { theme } = useData()
+const { config } = useConfig()
+
 const VPAlgoliaSearchBox = defineAsyncComponent(
   () => import('./VPAlgoliaSearchBox.vue')
 )
@@ -15,7 +16,7 @@ const loaded = ref(false)
 const metaKey = ref()
 
 onMounted(() => {
-  if (!theme.value.algolia) return
+  if (!config.value.algolia) return
 
   // meta key detect (same logic as in @docsearch/js)
   metaKey.value.textContent = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)
@@ -43,16 +44,13 @@ function load() {
 </script>
 
 <template>
-  <div v-if="theme.algolia" class="VPNavBarSearch">
+  <div v-if="config.algolia" class="VPNavBarSearch">
     <VPAlgoliaSearchBox v-if="loaded" />
     <div v-else id="docsearch" @click="load">
       <button
         type="button"
         class="DocSearch DocSearch-Button"
-        :aria-label="
-          theme?.messages?.search ??
-          'Search'
-        "
+        :aria-label="config.i18n?.search ?? 'Search'"
       >
         <span class="DocSearch-Button-Container">
           <svg
@@ -71,13 +69,11 @@ function load() {
             ></path>
           </svg>
           <span class="DocSearch-Button-Placeholder">{{
-            theme?.messages?.search ?? 'Search'
+            config.i18n?.search ?? 'Search'
           }}</span>
         </span>
         <span class="DocSearch-Button-Keys">
-          <span class="DocSearch-Button-Key" ref="metaKey">{{
-            theme?.messages?.meta ?? 'Meta'
-          }}</span>
+          <span class="DocSearch-Button-Key" ref="metaKey">Meta</span>
           <span class="DocSearch-Button-Key">K</span>
         </span>
       </button>

--- a/src/vitepress/components/VPNavBarSearch.vue
+++ b/src/vitepress/components/VPNavBarSearch.vue
@@ -49,7 +49,10 @@ function load() {
       <button
         type="button"
         class="DocSearch DocSearch-Button"
-        :aria-label="theme.messages.search"
+        :aria-label="
+          theme?.messages?.search ??
+          'Search'
+        "
       >
         <span class="DocSearch-Button-Container">
           <svg
@@ -67,10 +70,14 @@ function load() {
               stroke-linejoin="round"
             ></path>
           </svg>
-          <span class="DocSearch-Button-Placeholder">{{ theme.messages.search }}</span>
+          <span class="DocSearch-Button-Placeholder">{{
+            theme?.messages?.search ?? 'Search'
+          }}</span>
         </span>
         <span class="DocSearch-Button-Keys">
-          <span class="DocSearch-Button-Key" ref="metaKey">{{ theme.messages.meta }}</span>
+          <span class="DocSearch-Button-Key" ref="metaKey">{{
+            theme?.messages?.meta ?? 'Meta'
+          }}</span>
           <span class="DocSearch-Button-Key">K</span>
         </span>
       </button>

--- a/src/vitepress/components/VPNavScreenAppearance.vue
+++ b/src/vitepress/components/VPNavScreenAppearance.vue
@@ -9,7 +9,9 @@ const { config } = useConfig()
 
 <template>
   <div v-if="config.appearance" class="VPNavScreenAppearance">
-    <p class="text">{{ theme.messages.appearance }}</p>
+    <p class="text">{{
+      theme?.messages?.appearance ?? 'Appearance'
+    }}</p>
     <VTSwitchAppearance />
   </div>
 </template>

--- a/src/vitepress/components/VPNavScreenAppearance.vue
+++ b/src/vitepress/components/VPNavScreenAppearance.vue
@@ -1,17 +1,13 @@
 <script lang="ts" setup>
-import { useData } from 'vitepress'
 import { VTSwitchAppearance } from '../../core'
 import { useConfig } from '../composables/config'
 
-const { theme } = useData()
 const { config } = useConfig()
 </script>
 
 <template>
   <div v-if="config.appearance" class="VPNavScreenAppearance">
-    <p class="text">{{
-      theme?.messages?.appearance ?? 'Appearance'
-    }}</p>
+    <p class="text">{{ config.i18n?.appearance ?? 'Appearance' }}</p>
     <VTSwitchAppearance />
   </div>
 </template>

--- a/src/vitepress/components/VPNavScreenAppearance.vue
+++ b/src/vitepress/components/VPNavScreenAppearance.vue
@@ -1,13 +1,15 @@
 <script lang="ts" setup>
+import { useData } from 'vitepress'
 import { VTSwitchAppearance } from '../../core'
 import { useConfig } from '../composables/config'
 
+const { theme } = useData()
 const { config } = useConfig()
 </script>
 
 <template>
   <div v-if="config.appearance" class="VPNavScreenAppearance">
-    <p class="text">Appearance</p>
+    <p class="text">{{ theme.messages.appearance }}</p>
     <VTSwitchAppearance />
   </div>
 </template>

--- a/src/vitepress/components/VPNotFound.vue
+++ b/src/vitepress/components/VPNotFound.vue
@@ -1,32 +1,26 @@
 <script setup lang="ts">
-import { useData, useRoute } from 'vitepress'
+import { useRoute } from 'vitepress'
+import { useConfig } from '../composables/config'
 
-const { theme } = useData()
 const route = useRoute()
+const { config } = useConfig()
 </script>
 
 <template>
   <div class="vt-doc">
-    <h1>{{
-      theme?.messages?.pageNotFound ??
-      'Page Not Found'
-    }}</h1>
-    <p>{{
-      theme?.messages?.deadLinkFound?.before ??
-      'You found a dead link: '
-    }}<span class="not-found-path">{{ route.path }}</span>{{
-      theme?.messages?.deadLinkFound?.after ??
-      ''
-    }}<br /><span v-if="theme.repo">{{
-      theme?.messages?.deadLinkReport?.before ??
-      'Please '
-    }}<a :href="`https://github.com/${theme.repo}`" target="_blank">{{
-      theme?.messages?.deadLinkReport?.content ??
-      'let us know'
-    }}</a>{{
-      theme?.messages?.deadLinkReport?.after ??
-      ' so we can fix it.'
-    }}</span>
+    <h1>{{ config.i18n?.pageNotFound ?? 'Page Not Found' }}</h1>
+    <p>
+      {{ config.i18n?.deadLink?.before ?? 'You found a dead link: '
+      }}<span class="not-found-path">{{ route.path }}</span
+      >{{ config.i18n?.deadLink?.after ?? '' }}<br /><span
+        v-if="config.editLink?.repo"
+        >{{ config.i18n?.deadLinkReport?.before ?? 'Please '
+        }}<a
+          :href="`https://github.com/${config.editLink?.repo}`"
+          target="_blank"
+          >{{ config.i18n?.deadLinkReport?.link ?? 'let us know' }}</a
+        >{{ config.i18n?.deadLinkReport?.after ?? ' so we can fix it.' }}</span
+      >
     </p>
   </div>
 </template>

--- a/src/vitepress/components/VPNotFound.vue
+++ b/src/vitepress/components/VPNotFound.vue
@@ -7,17 +7,18 @@ const route = useRoute()
 
 <template>
   <div class="vt-doc">
-    <h1>Page Not Found</h1>
-    <p>
-      You found a dead link: <span class="not-found-path">{{ route.path }}</span
-      ><br />
-      <span v-if="theme.repo"
-        >Please
-        <a :href="`https://github.com/${theme.repo}`" target="_blank"
-          >let us know</a
-        >
-        so we can fix it.</span
-      >
+    <h1>{{ theme.messages.pageNotFound }}</h1>
+    <p>{{
+      theme.messages.deadLinkFound.before
+    }}<span class="not-found-path">{{ route.path }}</span>{{
+      theme.messages.deadLinkFound.after
+    }}<br /><span v-if="theme.repo">{{
+      theme.messages.deadLinkReport.before
+    }}<a :href="`https://github.com/${theme.repo}`" target="_blank">{{
+      theme.messages.deadLinkReport.content
+    }}</a>{{
+      theme.messages.deadLinkReport.after
+    }}</span>
     </p>
   </div>
 </template>

--- a/src/vitepress/components/VPNotFound.vue
+++ b/src/vitepress/components/VPNotFound.vue
@@ -7,17 +7,25 @@ const route = useRoute()
 
 <template>
   <div class="vt-doc">
-    <h1>{{ theme.messages.pageNotFound }}</h1>
+    <h1>{{
+      theme?.messages?.pageNotFound ??
+      'Page Not Found'
+    }}</h1>
     <p>{{
-      theme.messages.deadLinkFound.before
+      theme?.messages?.deadLinkFound?.before ??
+      'You found a dead link: '
     }}<span class="not-found-path">{{ route.path }}</span>{{
-      theme.messages.deadLinkFound.after
+      theme?.messages?.deadLinkFound?.after ??
+      ''
     }}<br /><span v-if="theme.repo">{{
-      theme.messages.deadLinkReport.before
+      theme?.messages?.deadLinkReport?.before ??
+      'Please '
     }}<a :href="`https://github.com/${theme.repo}`" target="_blank">{{
-      theme.messages.deadLinkReport.content
+      theme?.messages?.deadLinkReport?.content ??
+      'let us know'
     }}</a>{{
-      theme.messages.deadLinkReport.after
+      theme?.messages?.deadLinkReport?.after ??
+      ' so we can fix it.'
     }}</span>
     </p>
   </div>

--- a/src/vitepress/components/VPSidebar.vue
+++ b/src/vitepress/components/VPSidebar.vue
@@ -31,9 +31,10 @@ watchPostEffect(async () => {
   >
     <nav id="VPSidebarNav" aria-labelledby="sidebar-aria-label" tabindex="-1">
       <slot name="top" />
-      <span id="sidebar-aria-label" class="visually-hidden"
-        >{{ theme.messages.sidebarNavigation }}</span
-      >
+      <span id="sidebar-aria-label" class="visually-hidden">{{
+        theme?.messages?.sidebarNavigation ??
+        'Sidebar Navigation'
+      }}</span>
       <div v-for="group in sidebar" :key="group.text" class="group">
         <VPSidebarGroup :text="group.text" :items="group.items" />
       </div>

--- a/src/vitepress/components/VPSidebar.vue
+++ b/src/vitepress/components/VPSidebar.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
 import { nextTick, ref, watchPostEffect } from 'vue'
+import { useData } from 'vitepress'
 import { useSidebar } from '../composables/sidebar'
 import VPSidebarGroup from './VPSidebarGroup.vue'
 
+const { theme } = useData()
 const { sidebar, hasSidebar } = useSidebar()
 
 const props = defineProps<{
@@ -30,7 +32,7 @@ watchPostEffect(async () => {
     <nav id="VPSidebarNav" aria-labelledby="sidebar-aria-label" tabindex="-1">
       <slot name="top" />
       <span id="sidebar-aria-label" class="visually-hidden"
-        >Sidebar Navigation</span
+        >{{ theme.messages.sidebarNavigation }}</span
       >
       <div v-for="group in sidebar" :key="group.text" class="group">
         <VPSidebarGroup :text="group.text" :items="group.items" />

--- a/src/vitepress/components/VPSidebar.vue
+++ b/src/vitepress/components/VPSidebar.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
 import { nextTick, ref, watchPostEffect } from 'vue'
-import { useData } from 'vitepress'
+import { useConfig } from '../composables/config'
 import { useSidebar } from '../composables/sidebar'
 import VPSidebarGroup from './VPSidebarGroup.vue'
 
-const { theme } = useData()
 const { sidebar, hasSidebar } = useSidebar()
+const { config } = useConfig()
 
 const props = defineProps<{
   open: boolean
@@ -32,8 +32,7 @@ watchPostEffect(async () => {
     <nav id="VPSidebarNav" aria-labelledby="sidebar-aria-label" tabindex="-1">
       <slot name="top" />
       <span id="sidebar-aria-label" class="visually-hidden">{{
-        theme?.messages?.sidebarNavigation ??
-        'Sidebar Navigation'
+        config.i18n?.ariaSidebarNav ?? 'Sidebar Navigation'
       }}</span>
       <div v-for="group in sidebar" :key="group.text" class="group">
         <VPSidebarGroup :text="group.text" :items="group.items" />

--- a/src/vitepress/components/VPSkipLink.vue
+++ b/src/vitepress/components/VPSkipLink.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
-import { useRoute } from 'vitepress'
+import { useRoute, useData } from 'vitepress'
 
 const route = useRoute()
 const backToTop = ref()
+const { theme } = useData()
 
 watch(
   () => route.path,
@@ -35,7 +36,7 @@ const focusOnTargetAnchor = ({ target }: Event) => {
     class="VPSkipLink visually-hidden"
     @click="focusOnTargetAnchor"
   >
-    Skip to content
+    {{ theme.messages.skipToContent }}
   </a>
 </template>
 

--- a/src/vitepress/components/VPSkipLink.vue
+++ b/src/vitepress/components/VPSkipLink.vue
@@ -1,10 +1,11 @@
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
-import { useRoute, useData } from 'vitepress'
+import { useRoute } from 'vitepress'
+import { useConfig } from '../composables/config'
 
+const { config } = useConfig()
 const route = useRoute()
 const backToTop = ref()
-const { theme } = useData()
 
 watch(
   () => route.path,
@@ -35,10 +36,8 @@ const focusOnTargetAnchor = ({ target }: Event) => {
     href="#VPContent"
     class="VPSkipLink visually-hidden"
     @click="focusOnTargetAnchor"
-  >{{
-    theme?.messages?.skipToContent ??
-    'Skip to content'
-  }}</a>
+    >{{ config.i18n?.ariaSkipToContent ?? 'Skip to content' }}</a
+  >
 </template>
 
 <style scoped>

--- a/src/vitepress/components/VPSkipLink.vue
+++ b/src/vitepress/components/VPSkipLink.vue
@@ -35,9 +35,10 @@ const focusOnTargetAnchor = ({ target }: Event) => {
     href="#VPContent"
     class="VPSkipLink visually-hidden"
     @click="focusOnTargetAnchor"
-  >
-    {{ theme.messages.skipToContent }}
-  </a>
+  >{{
+    theme?.messages?.skipToContent ??
+    'Skip to content'
+  }}</a>
 </template>
 
 <style scoped>

--- a/src/vitepress/config.ts
+++ b/src/vitepress/config.ts
@@ -31,7 +31,7 @@ export interface Config {
   /**
    * The i18n messages.
    */
-  messages?: MessagesConfig
+  i18n?: i18nConfig
 
   /**
    * Info for the edit link
@@ -116,12 +116,29 @@ export interface SidebarGroup {
   items: MenuItemWithLink[]
 }
 
-export interface MessagesConfig {
-  [key: string]: string | SentenceMessage
+export interface i18nConfig {
+  search?: string
+  menu?: string
+  returnToTop?: string
+  appearance?: string
+  previous?: string
+  next?: string
+  pageNotFound?: string
+  deadLink?: MessageWithLink
+  deadLinkReport?: MessageWithLink
+  footerLicense?: MessageWithLink
+
+  ariaAnnouner?: MessageWithLink
+  ariaDarkMode?: string
+  ariaSkipToContent?: string
+  ariaToC?: string
+  ariaMainNav?: string
+  ariaMobileNav?: string
+  ariaSidebarNav?: string
 }
 
-export interface SentenceMessage {
+export interface MessageWithLink {
   before?: string
-  content?: string
+  link?: string
   after?: string
 }

--- a/src/vitepress/config.ts
+++ b/src/vitepress/config.ts
@@ -29,6 +29,11 @@ export interface Config {
   sidebar?: SidebarConfig
 
   /**
+   * The i18n messages.
+   */
+  messages?: MessagesConfig
+
+  /**
    * Info for the edit link
    */
   editLink?: {
@@ -109,4 +114,14 @@ export interface MultiSidebarConfig {
 export interface SidebarGroup {
   text: string
   items: MenuItemWithLink[]
+}
+
+export interface MessagesConfig {
+  [key: string]: string | SentenceMessage
+}
+
+export interface SentenceMessage {
+  before?: string
+  content?: string
+  after?: string
 }

--- a/src/vitepress/support/sidebar.ts
+++ b/src/vitepress/support/sidebar.ts
@@ -8,7 +8,7 @@ import { ensureStartingSlash } from './utils'
  * was found, it will return empty array.
  */
 export function getSidebar(
-  sidebar: SidebarConfig,
+  sidebar: SidebarConfig | undefined,
   path: string
 ): SidebarGroup[] {
   if (Array.isArray(sidebar)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "strict": true,
+    "jsx": "preserve",
     "esModuleInterop": true,
     "noUnusedLocals": true,
     "lib": ["ESNext", "DOM"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,6 @@
       "@vue/theme": ["src/index.ts"]
     }
   },
-  "include": [
-    "src",
-    "types",
-    "demo/.vitepress/theme"
-  ],
+  "include": ["src", "types", "demo/.vitepress/theme"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Support i18n messages by adding a new optional field: `themeConfig.messages` to the config. More details:

```js
const config = {
  // ...
  themeConfig: {
    // ...
    messages: {
      // basic-level
      search: 'Search',
      previous: 'Previous',
      next: 'Next',
      menu: 'Menu',
      appearance: 'Appearance',
      meta: 'Meta',

      // block-level
      pageNotFound: 'Page Not Found',
      tableOfContents: 'Table of Contents for current page',
      mainNavigation: 'Main Navigation',
      mobileNavigation: 'Mobile Navigation',
      sidebarNavigation: 'Sidebar Navigation',

      // sentence-level
      announcer: {
        before: '',
        after: ' has loaded'
      },
      footerLicense: {
        before: 'Released under the ',
        after: '.'
      },
      deadLinkFound: {
        before: 'You found a dead link: ',
        after: ''
      },
      deadLinkReport: {
        before: 'Please ',
        content: 'let us know',
        after: ' so we can fix it.'
      },

      // action-level
      toggleDarkMode: 'Toggle Dark Mode',
      returnToTop: 'Return to top',
      skipToContent: 'Skip to content'
    }
  }
}
```

Added type def:

```ts
export interface Config {
  // ...

  /**
   * The i18n messages.
   */
  messages?: MessagesConfig

  // ...
}
export interface MessagesConfig {
  [key: string]: string | SentenceMessage
}

export interface SentenceMessage {
  before?: string
  content?: string
  after?: string
}
```

Ref: Chinese doc site translation https://github.com/vuejs-translations/docs-zh-cn/pull/430

Thanks.