### PR TITLE
Fix a deprecated shiki API

### DIFF
--- a/src/vitepress/config/highlight.js
+++ b/src/vitepress/config/highlight.js
@@ -19,6 +19,6 @@ module.exports = async (theme = 'material-palenight') => {
     if (!lang || lang === 'text') {
       return `<pre v-pre><code>${escapeHtml(code)}</code></pre>`
     }
-    return highlighter.codeToHtml(code, lang).replace(/^<pre.*?>/, '<pre v-pre>')
+    return highlighter.codeToHtml(code, { lang }).replace(/^<pre.*?>/, '<pre v-pre>')
   }
 }


### PR DESCRIPTION
From `highlighter.codeToHtml(code, lang)` to `highlighter.codeToHtml(code, { lang })`. The previous one is actually already deprecated.

Ref: https://github.com/shikijs/shiki/blob/main/README.md