### PR TITLE
fix: page bottom - highlight last outline link

### DIFF
--- a/src/vitepress/composables/outline.ts
+++ b/src/vitepress/composables/outline.ts
@@ -53,7 +53,7 @@ export function useActiveAnchor(
     // page bottom - highlight last one
     if (
       anchors.length &&
-      window.scrollY + window.innerHeight >= document.body.offsetHeight
+      window.scrollY + window.innerHeight >= document.body.offsetHeight - 1
     ) {
       activateLink(anchors[anchors.length - 1].hash)
       return

--- a/src/vitepress/composables/outline.ts
+++ b/src/vitepress/composables/outline.ts
@@ -53,6 +53,7 @@ export function useActiveAnchor(
     // page bottom - highlight last one
     if (
       anchors.length &&
+      // https://github.com/vuejs/theme/pull/74
       window.scrollY + window.innerHeight >= document.body.offsetHeight - 1
     ) {
       activateLink(anchors[anchors.length - 1].hash)

--- a/src/vitepress/composables/outline.ts
+++ b/src/vitepress/composables/outline.ts
@@ -53,7 +53,7 @@ export function useActiveAnchor(
     // page bottom - highlight last one
     if (
       anchors.length &&
-      window.scrollY + window.innerHeight === document.body.offsetHeight
+      window.scrollY + window.innerHeight >= document.body.offsetHeight
     ) {
       activateLink(anchors[anchors.length - 1].hash)
       return


### PR DESCRIPTION
Checked in both Chrome and Edge, at bottom of page, `window.scrollY + window.innerHeight` > `document.body.offsetHeight`, last one didn't be highlighted

![image](https://user-images.githubusercontent.com/93325995/190200867-c187fd05-21bb-4d67-a931-7aa82f249291.png)
