### PR TITLE
Missing a way for translating Algolia search

### DIFF
--- a/demo/.vitepress/config.js
+++ b/demo/.vitepress/config.js
@@ -2,7 +2,7 @@ const getBase = require('../../src/vitepress/config/baseConfig')
 const path = require('path')
 
 /**
- * @type {() => Promise<import('vitepress').UserConfig}
+ * @type {() => Promise<import('vitepress').UserConfig>}
  */
 module.exports = (async () => {
   const base = await getBase()

--- a/demo/.vitepress/config.js
+++ b/demo/.vitepress/config.js
@@ -2,10 +2,11 @@ const getBase = require('../../src/vitepress/config/baseConfig')
 const path = require('path')
 
 /**
- * @type {() => Promise<import('vitepress').UserConfig>}
+ * @type {() => Promise<import('vitepress').UserConfig}
  */
 module.exports = (async () => {
   const base = await getBase()
+
   return {
     ...base,
 
@@ -25,13 +26,28 @@ module.exports = (async () => {
     title: 'Vue.js',
     description: 'Vue.js - The Progressive JavaScript Framework',
 
+    /**
+     * @type {import('../../src/vitepress/config').Config}
+     */
     themeConfig: {
       logo: '/img/logo-vue.svg',
 
       algolia: {
         indexName: 'vuejs-v3',
         appId: 'BH4D9OD16A',
-        apiKey: 'bc6e8acb44ed4179c30d0a45d6140d3f'
+        apiKey: 'bc6e8acb44ed4179c30d0a45d6140d3f',
+        placeholder: 'Search on Vue theme',
+        translations: {
+          modal: {
+            searchBox: {
+              cancelButtonText: 'Abort',
+              resetButtonTitle: 'Clear search term'
+            },
+            footer: {
+              searchByText: 'Search gracefully done by '
+            }
+          }
+        }
       },
 
       carbonAds: {

--- a/src/vitepress/components/VPAlgoliaSearchBox.vue
+++ b/src/vitepress/components/VPAlgoliaSearchBox.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import docsearch from '@docsearch/js'
 import { useRoute, useRouter } from 'vitepress'
-import { onMounted } from 'vue'
+import { onMounted, toRaw } from 'vue'
 import { useConfig } from '../composables/config'
 import type { AlgoliaSearchOptions } from '../config'
 
@@ -16,7 +16,7 @@ const router = useRouter()
 
 onMounted(() => {
   // this component will only render if user has configured algolia
-  initialize(config.value.algolia!)
+  initialize(toRaw(config.value.algolia!))
   setTimeout(poll, 16)
 })
 

--- a/src/vitepress/config.ts
+++ b/src/vitepress/config.ts
@@ -87,6 +87,55 @@ export interface AlgoliaSearchOptions {
   searchParameters?: any
   disableUserPersonalization?: boolean
   initialQuery?: string
+  translations?: Partial<DocSearchTranslations>
+}
+
+export interface DocSearchTranslations {
+  button?: ButtonTranslations
+  modal?: ModalTranslations
+}
+
+export interface ButtonTranslations {
+  buttonText?: string
+  buttonAriaLabel?: string
+}
+export interface ModalTranslations extends ScreenStateTranslations {
+  searchBox?: {
+    resetButtonTitle?: string
+    resetButtonAriaLabel?: string
+    cancelButtonText?: string
+    cancelButtonAriaLabel?: string
+  }
+  footer?: {
+    selectText?: string
+    selectKeyAriaLabel?: string
+    navigateText?: string
+    navigateUpKeyAriaLabel?: string
+    navigateDownKeyAriaLabel?: string
+    closeText?: string
+    closeKeyAriaLabel?: string
+    searchByText?: string
+  }
+}
+export interface ScreenStateTranslations {
+  errorScreen?: {
+    titleText?: string
+    helpText?: string
+  }
+  startScreen?: {
+    recentSearchesTitle?: string
+    noRecentSearchesText?: string
+    saveRecentSearchButtonTitle?: string
+    removeRecentSearchButtonTitle?: string
+    favoriteSearchesTitle?: string
+    removeFavoriteSearchButtonTitle?: string
+  }
+  noResultsScreen?: {
+    noResultsText?: string
+    suggestedQueryText?: string
+    reportMissingResultsText?: string
+    reportMissingResultsLinkText?: string
+  }
 }
 
 export type NavItem = NavItemWithLink | NavItemWithChildren


### PR DESCRIPTION
Hi,

during the translation of French Vue docs, I just get surprised that algolia search is not typed on translations part.
So I copy paste from DocSearch d.ts' file for making available for translators!