### PR TITLE
fix: break long words on overflow

### DIFF
--- a/demo/guide/installation.md
+++ b/demo/guide/installation.md
@@ -4,6 +4,8 @@
 
 ## Ordered List
 
+https://github.com/VSCodeVim/Vim#viminsertmodekeybindingsvimnormalmodekeybindingsvimvisualmodekeybindingsvimoperatorpendingmodekeybindings
+
 1. Automatically apply classes for CSS transitions and animations
 2. Integrate 3rd-party CSS animation libraries, such as Animate.css(opens new window)
 3. Use JavaScript to directly manipulate the DOM during transition hooks

--- a/demo/guide/installation.md
+++ b/demo/guide/installation.md
@@ -4,8 +4,6 @@
 
 ## Ordered List
 
-https://github.com/VSCodeVim/Vim#viminsertmodekeybindingsvimnormalmodekeybindingsvimvisualmodekeybindingsvimoperatorpendingmodekeybindings
-
 1. Automatically apply classes for CSS transitions and animations
 2. Integrate 3rd-party CSS animation libraries, such as Animate.css(opens new window)
 3. Use JavaScript to directly manipulate the DOM during transition hooks

--- a/src/core/styles/base.css
+++ b/src/core/styles/base.css
@@ -21,6 +21,7 @@ body {
   transition: color .5s, background-color .5s;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-wrap: break-word;
 }
 
 blockquote,
@@ -203,14 +204,4 @@ fieldset {
   position: absolute;
   white-space: nowrap;
   width: 1px;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p {
-  overflow-wrap: break-word;
 }

--- a/src/core/styles/base.css
+++ b/src/core/styles/base.css
@@ -204,3 +204,13 @@ fieldset {
   white-space: nowrap;
   width: 1px;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
A long link from vue playground:

![image](https://user-images.githubusercontent.com/53554371/204242350-c43f1ac4-c209-4a54-a261-74b04f40b860.png)
