### PR TITLE
feat(theme): add locales dropdown

### DIFF
--- a/src/core/components/VTFlyout.vue
+++ b/src/core/components/VTFlyout.vue
@@ -37,12 +37,14 @@ useFocusContainer({
       :aria-label="label"
       @click="open = !open"
     >
-      <span v-if="props.button" class="vt-flyout-button-text">
-        {{ props.button }}
-        <VTIconChevronDown class="vt-flyout-button-text-icon" />
-      </span>
+      <slot name="btn-slot">
+        <span v-if="props.button" class="vt-flyout-button-text">
+          {{ props.button }}
+          <VTIconChevronDown class="vt-flyout-button-text-icon" />
+        </span>
 
-      <VTIconMoreHorizontal v-else class="vt-flyout-button-icon" />
+        <VTIconMoreHorizontal v-else class="vt-flyout-button-icon" />
+      </slot>
     </button>
 
     <div class="vt-flyout-menu">

--- a/src/core/styles/index.css
+++ b/src/core/styles/index.css
@@ -12,6 +12,7 @@
 @import './vt-menu.css';
 @import './vt-menu-group.css';
 @import './vt-menu-link.css';
+@import './vt-locales.css';
 @import './vt-social-link.css';
 @import './vt-social-links.css';
 @import './vt-switch.css';

--- a/src/core/styles/vt-locales.css
+++ b/src/core/styles/vt-locales.css
@@ -1,0 +1,41 @@
+.vt-locales-btn-icon {
+  margin: 0 0.5rem;
+}
+.vt-locales-btn-icon-container {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+.vt-locales-btn-icon {
+  width: 1rem;
+  height: 1rem;
+  fill: var(--vt-c-text-1);
+}
+.vt-locales-menu-hr-divider {
+  margin-top: 4px;
+  margin-bottom: 4px;
+  width: 100%;
+  height: 1px;
+  background-color: var(--vt-c-divider-light);
+}
+.vt-locales-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 6px;
+  font-size: .875rem;
+  position: relative;
+}
+.vt-locales-menu-item-text {
+  cursor: pointer;
+}
+.vt-locales-menu-item-text:hover {
+  color: var(--vt-c-brand);
+}
+.vt-locales-menu-item.join-translations {
+  margin-top: 8px;
+  padding: 0 14px;
+}
+.VPNavBarLocaleScreen .vt-locales-menu-item.join-translations {
+  padding: 0;
+}

--- a/src/core/types/menu.ts
+++ b/src/core/types/menu.ts
@@ -16,3 +16,8 @@ export interface MenuItemChildWithChildren {
   text?: string
   items: MenuItemWithLink[]
 }
+
+export type LocaleLinkItem = MenuItemWithLink & {
+  repo?: string
+  isTranslationsDesc?: boolean
+}

--- a/src/vitepress/components/VPNavBarLocale.vue
+++ b/src/vitepress/components/VPNavBarLocale.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { useConfig } from '../composables/config'
+import { VTFlyout } from '../../core'
+import VTIconLanguagesVue from '../../core/components/icons/VTIconLanguages.vue';
+import VPNavBarLocaleItems from './VPNavBarLocaleItems.vue'
+import VPNavBarLocaleJoin from './VPNavBarLocaleJoin.vue';
+
+const { config } = useConfig()
+const localeLinks = config.value.localeLinks
+</script>
+
+<template>
+  <VTFlyout 
+    class="VPNavBarMenuGroup active VPNavBarLocale" 
+  >
+    <template #btn-slot>
+      <div class="vt-locales-btn-icon-container">
+        <VTIconLanguagesVue class="vt-locales-btn-icon" />
+      </div>
+    </template>
+
+    <template v-if="localeLinks">
+      <div  class="vt-menu-items x-padding">
+        <VPNavBarLocaleItems />
+      </div>
+      <VPNavBarLocaleJoin />
+    </template>
+  </VTFlyout>
+</template>
+
+<style scoped>
+.vt-locales-btn-icon-container::before,
+.vt-locales-btn-icon-container::after {
+  width: 1px;
+  height: 24px;
+  background-color: var(--vt-c-divider-light);
+  content: "";
+}
+.vt-locales-btn-icon-container::before {
+  margin-right: 4px;
+}
+.vt-locales-btn-icon-container::after {
+  margin-left: 4px;
+}
+.vt-menu-items {
+  padding: 0 14px;
+}
+</style>

--- a/src/vitepress/components/VPNavBarLocale.vue
+++ b/src/vitepress/components/VPNavBarLocale.vue
@@ -10,9 +10,7 @@ const localeLinks = config.value.localeLinks
 </script>
 
 <template>
-  <VTFlyout 
-    class="VPNavBarMenuGroup active VPNavBarLocale" 
-  >
+  <VTFlyout class="VPNavBarMenuGroup active VPNavBarLocale">
     <template #btn-slot>
       <div class="vt-locales-btn-icon-container">
         <VTIconLanguagesVue class="vt-locales-btn-icon" />
@@ -20,7 +18,7 @@ const localeLinks = config.value.localeLinks
     </template>
 
     <template v-if="localeLinks">
-      <div  class="vt-menu-items x-padding">
+      <div class="vt-menu-items x-padding">
         <VPNavBarLocaleItems />
       </div>
       <VPNavBarLocaleJoin />
@@ -36,12 +34,15 @@ const localeLinks = config.value.localeLinks
   background-color: var(--vt-c-divider-light);
   content: "";
 }
+
 .vt-locales-btn-icon-container::before {
   margin-right: 4px;
 }
+
 .vt-locales-btn-icon-container::after {
   margin-left: 4px;
 }
+
 .vt-menu-items {
   padding: 0 14px;
 }

--- a/src/vitepress/components/VPNavBarLocaleItems.vue
+++ b/src/vitepress/components/VPNavBarLocaleItems.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { LocaleLinkItem } from '../../core'
+import { VTIconExternalLink } from '../../core';
+import { useConfig } from '../composables/config'
+import VTIconGitHub from '../../core/components/icons/VTIconGitHub.vue';
+
+const { config } = useConfig()
+const localeLinks = config.value.localeLinks?.filter(
+  item => !item.isTranslationsDesc
+)
+
+const autoAppendSlash = (url: string) => url.endsWith('/') ? url : url + '/'
+const onLocaleSelect = (item: LocaleLinkItem) => {
+  const { href: currentHref, origin: currentOrigin } = window.location
+    ,startOfOrigin = currentHref.indexOf(currentOrigin)
+  window.location.href = autoAppendSlash(item.link) + currentHref.slice(startOfOrigin + currentOrigin.length)
+}
+</script>
+
+<template>
+  <div v-for="item in localeLinks" :key="item.text" class="vt-locales-menu-item">
+    <div 
+      :href="item.link"
+      class="vt-locales-menu-item-text"
+      @click="onLocaleSelect(item)"
+    >
+      {{ item.text }}
+      <VTIconExternalLink class="vt-link-icon" />
+    </div>
+    <a :href="item.repo ?? ''" target="_blank" class="vt-locales-btn-icon-container">
+      <VTIconGitHub class="vt-locales-btn-icon repo" />
+    </a>
+  </div>
+</template>

--- a/src/vitepress/components/VPNavBarLocaleItems.vue
+++ b/src/vitepress/components/VPNavBarLocaleItems.vue
@@ -12,7 +12,7 @@ const localeLinks = config.value.localeLinks?.filter(
 const autoAppendSlash = (url: string) => url.endsWith('/') ? url : url + '/'
 const onLocaleSelect = (item: LocaleLinkItem) => {
   const { href: currentHref, origin: currentOrigin } = window.location
-    ,startOfOrigin = currentHref.indexOf(currentOrigin)
+    , startOfOrigin = currentHref.indexOf(currentOrigin)
   window.location.href = autoAppendSlash(item.link) + currentHref.slice(startOfOrigin + currentOrigin.length)
 }
 </script>

--- a/src/vitepress/components/VPNavBarLocaleJoin.vue
+++ b/src/vitepress/components/VPNavBarLocaleJoin.vue
@@ -1,0 +1,36 @@
+<script lang="ts" setup>
+import { computed, inject } from 'vue';
+import { useRouter } from 'vitepress';
+import { useConfig } from '../composables/config'
+
+const router = useRouter()
+const { config } = useConfig()
+const closeScreen = inject<() => void>('close-screen')!
+const localeLinks = config.value.localeLinks
+const translationsDesc = computed(() => localeLinks?.find(
+  item => item.isTranslationsDesc
+))
+const navigateToJoinTranslation = () => {
+  if (translationsDesc.value) {
+    closeScreen()
+    router.go(translationsDesc.value.link)
+  }
+}
+</script>
+
+<template>
+  <template v-if="translationsDesc">
+    <div class="vt-locales-menu-hr-divider" />
+    <div class="vt-locales-menu-item join-translations">
+      <div class="vt-locales-menu-item-text" @click="navigateToJoinTranslation">
+        {{ translationsDesc.text }}
+      </div>
+    </div>
+  </template>
+</template>
+
+<style scoped>
+.vt-locales-menu-item {
+  padding-bottom: 0;
+}
+</style>

--- a/src/vitepress/components/VPNavBarMenu.vue
+++ b/src/vitepress/components/VPNavBarMenu.vue
@@ -2,6 +2,7 @@
 import { useConfig } from '../composables/config'
 import VPNavBarMenuLink from './VPNavBarMenuLink.vue'
 import VPNavBarMenuGroup from './VPNavBarMenuGroup.vue'
+import VPNavBarLocale from './VPNavBarLocale.vue';
 
 const { config } = useConfig()
 </script>
@@ -19,6 +20,7 @@ const { config } = useConfig()
       <VPNavBarMenuLink v-if="'link' in item" :item="item" />
       <VPNavBarMenuGroup v-else :item="item" />
     </template>
+    <VPNavBarLocale v-if="config.localeLinks" />
   </nav>
 </template>
 

--- a/src/vitepress/components/VPNavBarScreenLocale.vue
+++ b/src/vitepress/components/VPNavBarScreenLocale.vue
@@ -1,0 +1,35 @@
+<script lang="ts" setup>
+import { useConfig } from '../composables/config'
+import VPNavBarLocaleItems from './VPNavBarLocaleItems.vue';
+import VPNavBarLocaleJoin from './VPNavBarLocaleJoin.vue';
+
+const { config } = useConfig()
+</script>
+
+<template>
+  <div v-if="config.appearance" class="VPNavBarLocaleScreen">
+    <p class="title">{{ config.i18n?.locales ?? 'Translations' }}</p>
+    <VPNavBarLocaleItems />
+    <VPNavBarLocaleJoin />
+  </div>
+</template>
+
+<style scoped>
+.VPNavBarLocaleScreen {
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+  padding: 12px 14px 12px 16px;
+  background-color: var(--vt-c-bg-soft);
+  transition: background-color 0.5s;
+  margin: 16px 0;
+}
+.title {
+  line-height: 24px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--vt-c-text-2);
+  transition: color 0.5s;
+  margin-bottom: 6px;
+}
+</style>

--- a/src/vitepress/components/VPNavBarScreenLocale.vue
+++ b/src/vitepress/components/VPNavBarScreenLocale.vue
@@ -24,6 +24,7 @@ const { config } = useConfig()
   transition: background-color 0.5s;
   margin: 16px 0;
 }
+
 .title {
   line-height: 24px;
   font-size: 12px;

--- a/src/vitepress/components/VPNavScreen.vue
+++ b/src/vitepress/components/VPNavScreen.vue
@@ -84,15 +84,15 @@ function unlockBodyScroll() {
   max-width: 288px;
 }
 
-.menu + .appearance {
+.menu+.appearance {
   margin-top: 24px;
 }
 
-.menu + .social-links {
+.menu+.social-links {
   margin-top: 16px;
 }
 
-.appearance + .social-links {
+.appearance+.social-links {
   margin-top: 12px;
 }
 </style>

--- a/src/vitepress/components/VPNavScreen.vue
+++ b/src/vitepress/components/VPNavScreen.vue
@@ -4,6 +4,7 @@ import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 import VPNavScreenMenu from './VPNavScreenMenu.vue'
 import VPNavScreenAppearance from './VPNavScreenAppearance.vue'
 import VPNavScreenSocialLinks from './VPNavScreenSocialLinks.vue'
+import VPNavBarScreenLocale from './VPNavBarScreenLocale.vue'
 
 defineProps<{
   open: boolean
@@ -29,6 +30,7 @@ function unlockBodyScroll() {
     <div v-if="open" class="VPNavScreen" ref="screen">
       <div class="container">
         <VPNavScreenMenu class="menu" />
+        <VPNavBarScreenLocale />
         <VPNavScreenAppearance class="appearance" />
         <VPNavScreenSocialLinks class="social-links" />
       </div>

--- a/src/vitepress/config.ts
+++ b/src/vitepress/config.ts
@@ -1,4 +1,5 @@
 import {
+  LocaleLinkItem,
   MenuItemChildWithChildren,
   MenuItemWithLink,
   SocialLink
@@ -73,6 +74,11 @@ export interface Config {
     code: string
     placement: string
   }
+
+  /**
+   * Translation/Locales links
+   */
+  localeLinks?: LocaleLinkItem[]
 }
 
 /**
@@ -174,6 +180,8 @@ export interface i18nConfig {
   previous?: string
   next?: string
   pageNotFound?: string
+  locales?: string
+  joinTranslation?: string
   deadLink?: MessageWithLink
   deadLinkReport?: MessageWithLink
   footerLicense?: MessageWithLink


### PR DESCRIPTION
This is a feature implementation of https://github.com/vuejs/docs/issues/2095
@yyx990803 Please take a look ~

## For VitePress Configuration

```typescript
import type { Config as ThemeConfig } from '@vue/theme'

export default defineConfigWithTheme<ThemeConfig>({
  themeConfig: {
     ...,
     localeLinks: [
      {
        link: 'https://cn.vuejs.org',
        text: '简体中文', 
        repo: 'https://github.com/vuejs-translations/docs-zh-cn' 
      }, 
      { 
        link: 'https://ja.vuejs.org', 
        text: '日本語', 
        repo: 'https://github.com/vuejs-translations/docs-ja'
      },
      { 
        link: '/translations/', 
        text: 'Join in translation', 
        isTranslationsDesc: true 
      }
    ],
  }
})

```


## Preview

### Basic function
> it goes to the same page (with matching hash) of that translation.

![基本实现](https://user-images.githubusercontent.com/46062972/202571820-d354168f-9b03-4f5a-af7c-604c5b6d115b.gif)

## Go to Docs Repo

Click the github icon, can navigate to translation repo page. the URL is provided by the theme configuration `localeLinks`, which we've shown above.

![打开文档仓库](https://user-images.githubusercontent.com/46062972/202576035-5c4a1107-a328-452d-b63c-bd067bf604e0.gif)

### Responsive

design for different device sizes is required.

![响应式设计](https://user-images.githubusercontent.com/46062972/202572804-b3548545-d5ec-42ba-a16d-960ca9782317.gif)

### Edge cases

Should close dropdown menu, and if the viewport is mobile screen mode for now, we're supposed to close screen menu after click internal link, to display the content page.

![点击后需关闭 dropdown](https://user-images.githubusercontent.com/46062972/202573933-15ff2ca4-3e21-4fd8-809e-0a46454a40ee.gif)



