### PR TITLE
fix: remove a surplus of slash when switching languages

### DIFF
--- a/src/vitepress/components/VPNavBarLocaleItems.vue
+++ b/src/vitepress/components/VPNavBarLocaleItems.vue
@@ -9,11 +9,11 @@ const localeLinks = config.value.localeLinks?.filter(
   item => !item.isTranslationsDesc
 )
 
-const autoAppendSlash = (url: string) => url.endsWith('/') ? url : url + '/'
+const removeEndSlash = (url: string) => url.endsWith('/') ? url.substring(0, url.length -1) : url
 const onLocaleSelect = (item: LocaleLinkItem) => {
   const { href: currentHref, origin: currentOrigin } = window.location
     , startOfOrigin = currentHref.indexOf(currentOrigin)
-  window.location.href = autoAppendSlash(item.link) + currentHref.slice(startOfOrigin + currentOrigin.length)
+  window.location.href = removeEndSlash(item.link) + currentHref.slice(startOfOrigin + currentOrigin.length)
 }
 </script>
 


### PR DESCRIPTION
When switching languages, double slashes appear in the url.

![fix-surplus-slash](https://user-images.githubusercontent.com/1532716/216750964-c77099b6-2955-4338-9442-91d32176c2ca.png)
