### PR TITLE
fix: add calculated max height and overflow auto

### DIFF
--- a/src/core/styles/vt-flyout.css
+++ b/src/core/styles/vt-flyout.css
@@ -64,4 +64,5 @@
   visibility: hidden;
   transform: translateY(-4px);
   transition: opacity .25s, visibility .25s, transform .25s;
+  max-height: calc(100vh - var(--vt-nav-height));
 }

--- a/src/core/styles/vt-flyout.css
+++ b/src/core/styles/vt-flyout.css
@@ -57,6 +57,7 @@
 }
 
 .vt-flyout-menu {
+  display: flex;
   position: absolute;
   top: calc(var(--vt-nav-height) / 2 + 15px);
   right: 0;

--- a/src/core/styles/vt-menu.css
+++ b/src/core/styles/vt-menu.css
@@ -6,6 +6,7 @@
   background: var(--vt-c-bg);
   box-shadow: var(--vt-shadow-3);
   transition: background-color .5s;
+  overflow: auto;
 }
 
 .dark .vt-menu {


### PR DESCRIPTION
By adding a calculated max height to the VT Flyout menu and an overflow auto to the VT Menu, this makes the submenu fully accessible again :)


https://user-images.githubusercontent.com/2922851/228395761-bc2ccbf9-ab04-466f-947d-dc9e111b6ca6.mp4

Fixes #91 