### PR TITLE
fix: flyout menu height with banner

### DIFF
--- a/src/core/styles/vt-flyout.css
+++ b/src/core/styles/vt-flyout.css
@@ -65,5 +65,5 @@
   visibility: hidden;
   transform: translateY(-4px);
   transition: opacity .25s, visibility .25s, transform .25s;
-  max-height: calc(100vh - var(--vt-nav-height));
+  max-height: calc(100vh - var(--vt-nav-height) - var(--vt-banner-height, 0px));
 }


### PR DESCRIPTION
This is able to be reproduced on vuejs homepage:

Before with banner
![image](https://github.com/vuejs/theme/assets/206848/e546bc74-c30e-4672-8b08-54c3bf09ba50)
Before without banner
![image](https://github.com/vuejs/theme/assets/206848/e1d3c973-8e34-4122-a74c-e9aa02422975)

After with banner
![image](https://github.com/vuejs/theme/assets/206848/e61da269-1035-4fe0-975a-8d6ee3ec1b84)
After without banner
![image](https://github.com/vuejs/theme/assets/206848/2b1ea122-99fb-4f0c-a402-e1c44d22086d)
