### PR TITLE
fix: fixup link related error after configurating base URL

### DIFF
--- a/src/vitepress/components/VPContentDocFooter.vue
+++ b/src/vitepress/components/VPContentDocFooter.vue
@@ -42,7 +42,7 @@ function getFlatSideBarLinks(sidebar: SidebarGroup[]): MenuItemWithLink[] {
     <a
       v-if="links.prev"
       class="prev-link"
-      :href="normalizeLink(links.prev.link)"
+      :href="links.prev.link"
     >
       <span class="desc">
         <VTIconChevronLeft class="vt-link-icon" />
@@ -53,7 +53,7 @@ function getFlatSideBarLinks(sidebar: SidebarGroup[]): MenuItemWithLink[] {
     <a
       v-if="links.next"
       class="next-link"
-      :href="normalizeLink(links.next.link)"
+      :href="links.next.link"
     >
       <span class="desc">
         {{ config.i18n?.next ?? 'Next' }}

--- a/src/vitepress/support/utils.ts
+++ b/src/vitepress/support/utils.ts
@@ -41,7 +41,7 @@ export function isActive(
   if (matchPath === undefined) {
     return false
   }
-  currentPath = normalize(`/${currentPath}`)
+  currentPath = withBase(normalize(`/${currentPath}`))
   if (asRegex) {
     return new RegExp(matchPath).test(currentPath)
   } else {


### PR DESCRIPTION
When deploing Vue doc project on local environment with base URL configuration, the sidebar link active status is wrong. And footer link is wrong also.

This PR fix this issue to make local deployment experience better.