### PR TITLE
fix: don't escape entities in headers again

### DIFF
--- a/src/vitepress/components/VPDocOutlineItem.vue
+++ b/src/vitepress/components/VPDocOutlineItem.vue
@@ -21,9 +21,7 @@ function onClick({ target: el }: Event) {
 <template>
   <ul :class="nested ? 'nested' : 'root'">
     <li v-for="{ children, link, text, hidden } in headers">
-      <a class="outline-link" :href="link" @click="onClick" v-show="!hidden">{{
-        text
-      }}</a>
+      <a class="outline-link" :href="link" @click="onClick" v-show="!hidden" v-html="text" />
       <template v-if="children?.length && frontmatter.outline === 'deep'">
         <VPDocOutlineItem :headers="children" :nested="true" />
       </template>


### PR DESCRIPTION
syncing with vitepress changes - it might be possible that the data returned by mdit-vue/plugin-headers has already escaped html entities (e.g. `&amp;`). using moustache syntax would result in that being rendered as-is while we want to render simply `&` there.