### PR TITLE
chore: use tiny-decode instead of v-html+escapeHtml

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "@docsearch/js": "^3.6.0",
     "@vueuse/core": "^10.9.0",
     "body-scroll-lock": "^4.0.0-beta.0",
-    "normalize.css": "^8.0.1"
+    "normalize.css": "^8.0.1",
+    "tiny-decode": "^0.1.3"
   },
   "devDependencies": {
     "@mdit-vue/types": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
+      tiny-decode:
+        specifier: ^0.1.3
+        version: 0.1.3
     devDependencies:
       '@mdit-vue/types':
         specifier: ^2.1.0
@@ -649,6 +652,9 @@ packages:
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
+  tiny-decode@0.1.3:
+    resolution: {integrity: sha512-1z+tXaZpPUyREOfjKDQj5lR6HfD6Pa4NF7pb/9ep7sP4+X5WF76bGdJktWCY1Rm+aMR46vJ75VAL/oAptpD1AA==}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -1298,6 +1304,10 @@ snapshots:
   speakingurl@14.0.1: {}
 
   tabbable@6.2.0: {}
+
+  tiny-decode@0.1.3:
+    dependencies:
+      entities: 4.5.0
 
   to-fast-properties@2.0.0: {}
 

--- a/src/vitepress/components/VPDocOutlineItem.vue
+++ b/src/vitepress/components/VPDocOutlineItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { useData, _escapeHtml } from 'vitepress'
+import { decode } from 'tiny-decode'
+import { useData } from 'vitepress'
 import type { MenuItemWithLinkAndChildren } from '../composables/outline.js'
 
 defineProps<{
@@ -21,13 +22,9 @@ function onClick({ target: el }: Event) {
 <template>
   <ul :class="nested ? 'nested' : 'root'">
     <li v-for="{ children, link, text, hidden } in headers">
-      <a
-        class="outline-link"
-        :href="link"
-        @click="onClick"
-        v-show="!hidden"
-        v-html="_escapeHtml(text)"
-      />
+      <a class="outline-link" :href="link" @click="onClick" v-show="!hidden">
+        {{ decode(text) }}
+      </a>
       <template v-if="children?.length && frontmatter.outline === 'deep'">
         <VPDocOutlineItem :headers="children" :nested="true" />
       </template>


### PR DESCRIPTION
fixes the concerns in #106

/cc @Jinjiang you can try something like this in `demo/guide/introduction.md` to test:

```md
## What &amp; &#123;&#123; &lt;script&gt; (1) &#125;&#125; \<script setup> is Vue.js?
```

The browser bundle only has this code (<200B after gzip/br):

```ts
const n=/&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-fA-F]{1,6});?/gi;let t;function o(e){return t||(t=new DOMParser),t.parseFromString(e,"text/html").documentElement.textContent}function c(e){return n.lastIndex=0,e.replace(n,r=>o(r))
```

unminified:

```ts
const ENTITY_RE = /&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-fA-F]{1,6});?/gi;
let p;
function decodeHTML5(value) {
  if (!p)
    p = new DOMParser();
  return p.parseFromString(value, "text/html").documentElement.textContent;
}
function decode(value) {
  ENTITY_RE.lastIndex = 0;
  return value.replace(ENTITY_RE, (m) => decodeHTML5(m));
}
```