### PR TITLE
Add badge support to navigation and sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 TODOs.md
 .DS_Store
 demo/.vitepress/cache
+.idea

--- a/src/core/components/VTFlyout.vue
+++ b/src/core/components/VTFlyout.vue
@@ -1,15 +1,17 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import { MenuItem, MenuItemChild } from '../types/menu'
+import { MenuBadgeItem, MenuItem, MenuItemChild } from '../types/menu'
 import { useFocusContainer } from '../composables/FocusContainer'
 import VTIconChevronDown from './icons/VTIconChevronDown.vue'
 import VTIconMoreHorizontal from './icons/VTIconMoreHorizontal.vue'
 import VTMenu from './VTMenu.vue'
+import VTMenuBadge from './VTMenuBadge.vue'
 
 const props = defineProps<{
   button?: string
   items?: (MenuItem | MenuItemChild)[]
   label?: string
+  badge?: MenuBadgeItem
 }>()
 
 const open = ref(false)
@@ -40,6 +42,7 @@ useFocusContainer({
       <slot name="btn-slot">
         <span v-if="props.button" class="vt-flyout-button-text">
           {{ props.button }}
+          <VTMenuBadge v-if="badge" :item="badge" />
           <VTIconChevronDown class="vt-flyout-button-text-icon" />
         </span>
 

--- a/src/core/components/VTLink.vue
+++ b/src/core/components/VTLink.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
+import { MenuBadgeItem } from '../types/menu'
 import VTIconExternalLink from './icons/VTIconExternalLink.vue'
+import VTMenuBadge from './VTMenuBadge.vue'
 
 const props = defineProps<{
   href?: string
   noIcon?: boolean
+  badge?: MenuBadgeItem
 }>()
-
 const isExternal = computed(() => props.href && /^[a-z]+:/i.test(props.href))
 </script>
 
@@ -20,6 +22,7 @@ const isExternal = computed(() => props.href && /^[a-z]+:/i.test(props.href))
     :rel="isExternal ? 'noopener noreferrer' : undefined"
   >
     <slot />
+    <VTMenuBadge v-if="badge" :item="badge" />
     <VTIconExternalLink v-if="isExternal && !noIcon" class="vt-link-icon" />
   </component>
 </template>

--- a/src/core/components/VTMenuBadge.vue
+++ b/src/core/components/VTMenuBadge.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { MenuBadgeItem } from '../../core'
+
+defineProps<{ item: MenuBadgeItem }>()
+</script>
+
+<template>
+  <span class="vt-menu-badge" :class="item.type">{{ item.text }}</span>
+</template>

--- a/src/core/components/VTMenuLink.vue
+++ b/src/core/components/VTMenuLink.vue
@@ -6,7 +6,7 @@ defineProps<{ item: MenuItemWithLink }>()
 </script>
 
 <template>
-  <VTLink class="vt-menu-link" :href="item.link">
+  <VTLink class="vt-menu-link" :href="item.link" :badge="item.badge">
     {{ item.text }}
   </VTLink>
 </template>

--- a/src/core/styles/index.css
+++ b/src/core/styles/index.css
@@ -10,6 +10,7 @@
 @import './vt-hamburger.css';
 @import './vt-link.css';
 @import './vt-menu.css';
+@import './vt-menu-badge.css';
 @import './vt-menu-group.css';
 @import './vt-menu-link.css';
 @import './vt-locales.css';

--- a/src/core/styles/vt-menu-badge.css
+++ b/src/core/styles/vt-menu-badge.css
@@ -1,13 +1,13 @@
 .vt-menu-badge {
   display: inline-block;
-  padding: 6px;
+  padding: 3.5px 4px;
   margin-left: 6px;
   font-size: 10px;
   font-style: normal;
   font-weight: 600;
-  line-height: 10px; /* 240% */
-  letter-spacing: 0.2px;
-  border-radius: 4px;
+  line-height: 1;
+  letter-spacing: .2px;
+  border-radius: 6px;
   background: var(--vt-c-blue);
   color: var(--vt-c-white-soft);
 }

--- a/src/core/styles/vt-menu-badge.css
+++ b/src/core/styles/vt-menu-badge.css
@@ -1,0 +1,35 @@
+.vt-menu-badge {
+  display: inline-block;
+  padding: 6px;
+  margin-left: 6px;
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 10px; /* 240% */
+  letter-spacing: 0.2px;
+  border-radius: 4px;
+  background: var(--vt-c-blue);
+  color: var(--vt-c-white-soft);
+}
+
+.vt-menu-badge.secondary {
+  background: var(--vt-c-gray-light-5);
+  color: var(--vt-c-blue-dark);
+}
+
+.vt-menu-badge.success {
+  background: var(--vt-c-green);
+}
+
+.vt-menu-badge.info {
+  background: var(--vt-c-indigo-soft);
+}
+
+.vt-menu-badge.warning {
+  background: var(--vt-c-yellow-light);
+  color: var(--vt-c-black-soft);
+}
+
+.vt-menu-badge.danger {
+  background: var(--vt-c-red);
+}

--- a/src/core/types/menu.ts
+++ b/src/core/types/menu.ts
@@ -3,6 +3,7 @@ export type MenuItem = MenuItemWithLink | MenuItemWithChildren
 export interface MenuItemWithLink {
   text: string
   link: string
+  badge?: MenuBadgeItem
 }
 
 export interface MenuItemWithChildren {
@@ -15,6 +16,11 @@ export type MenuItemChild = MenuItemWithLink | MenuItemChildWithChildren
 export interface MenuItemChildWithChildren {
   text?: string
   items: MenuItemWithLink[]
+}
+
+export interface MenuBadgeItem {
+  text: string
+  type?: 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'danger'
 }
 
 export type LocaleLinkItem = MenuItemWithLink & {

--- a/src/vitepress/components/VPNavBarMenuGroup.vue
+++ b/src/vitepress/components/VPNavBarMenuGroup.vue
@@ -18,6 +18,7 @@ const { page } = useData()
       active: isActive(page.relativePath, item.activeMatch, true)
     }"
     :button="item.text"
+    :badge="item.badge"
     :items="item.items"
   />
 </template>

--- a/src/vitepress/components/VPNavBarMenuLink.vue
+++ b/src/vitepress/components/VPNavBarMenuLink.vue
@@ -22,6 +22,7 @@ const { page } = useData()
       )
     }"
     :href="item.link"
+    :badge="item.badge"
     :noIcon="true"
   >
     {{ item.text }}

--- a/src/vitepress/components/VPNavScreenMenu.vue
+++ b/src/vitepress/components/VPNavScreenMenu.vue
@@ -12,11 +12,13 @@ const { config } = useConfig()
       <VPNavScreenMenuLink
         v-if="'link' in item"
         :text="item.text"
+        :badge="item.badge"
         :link="item.link"
       />
       <VPNavScreenMenuGroup
         v-else
         :text="item.text || ''"
+        :badge="item.badge"
         :items="item.items"
       />
     </template>

--- a/src/vitepress/components/VPNavScreenMenuGroup.vue
+++ b/src/vitepress/components/VPNavScreenMenuGroup.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import { VTIconPlus, MenuItemChild } from '../../core'
+import { VTIconPlus, MenuItemChild, MenuBadgeItem } from '../../core'
 import VPNavScreenMenuGroupLink from './VPNavScreenMenuGroupLink.vue'
 import VPNavScreenMenuGroupSection from './VPNavScreenMenuGroupSection.vue'
+import VTMenuBadge from '../../core/components/VTMenuBadge.vue'
 
 const props = defineProps<{
   text: string
+  badge?: MenuBadgeItem
   items: MenuItemChild[]
 }>()
 
@@ -28,7 +30,10 @@ function toggle() {
       :aria-expanded="isOpen"
       @click="toggle"
     >
-      <span class="button-text">{{ text }}</span>
+      <div>
+        <span class="button-text">{{ text }}</span>
+        <VTMenuBadge v-if="badge" :item="badge" />
+      </div>
       <VTIconPlus class="button-icon" />
     </button>
 
@@ -38,6 +43,7 @@ function toggle() {
           <VPNavScreenMenuGroupLink
             :text="item.text"
             :link="item.link"
+            :badge="item.badge"
           />
         </div>
 

--- a/src/vitepress/components/VPNavScreenMenuGroupLink.vue
+++ b/src/vitepress/components/VPNavScreenMenuGroupLink.vue
@@ -1,17 +1,18 @@
 <script lang="ts" setup>
-import { VTLink } from '../../core'
+import { VTLink, MenuBadgeItem } from '../../core'
 import { inject } from 'vue'
 
 defineProps<{
   text: string
   link: string
+  badge?: MenuBadgeItem
 }>()
 
 const closeScreen = inject('close-screen') as () => void
 </script>
 
 <template>
-  <VTLink class="VPNavScreenMenuGroupLink" :href="link" @click="closeScreen">
+  <VTLink class="VPNavScreenMenuGroupLink" :href="link" :badge="badge" @click="closeScreen">
     {{ text }}
   </VTLink>
 </template>

--- a/src/vitepress/components/VPNavScreenMenuGroupSection.vue
+++ b/src/vitepress/components/VPNavScreenMenuGroupSection.vue
@@ -16,6 +16,7 @@ defineProps<{
       :key="item.text"
       :text="item.text"
       :link="item.link"
+      :badge="item.badge"
     />
   </div>
 </template>

--- a/src/vitepress/components/VPNavScreenMenuLink.vue
+++ b/src/vitepress/components/VPNavScreenMenuLink.vue
@@ -1,17 +1,18 @@
 <script lang="ts" setup>
-import { VTLink } from '../../core'
+import { MenuBadgeItem, VTLink } from '../../core'
 import { inject } from 'vue'
 
 defineProps<{
   text: string
   link: string
+  badge?: MenuBadgeItem
 }>()
 
 const closeScreen = inject('close-screen') as () => void
 </script>
 
 <template>
-  <VTLink class="VPNavScreenMenuLink" :href="link" @click="closeScreen">
+  <VTLink class="VPNavScreenMenuLink" :href="link" :badge="badge" @click="closeScreen">
     {{ text }}
   </VTLink>
 </template>

--- a/src/vitepress/components/VPSidebar.vue
+++ b/src/vitepress/components/VPSidebar.vue
@@ -35,7 +35,7 @@ watchPostEffect(async () => {
         config.i18n?.ariaSidebarNav ?? 'Sidebar Navigation'
       }}</span>
       <div v-for="group in sidebar" :key="group.text" class="group">
-        <VPSidebarGroup :text="group.text" :items="group.items" />
+        <VPSidebarGroup :text="group.text" :badge="group.badge" :items="group.items"/>
       </div>
       <slot name="bottom" />
     </nav>

--- a/src/vitepress/components/VPSidebarGroup.vue
+++ b/src/vitepress/components/VPSidebarGroup.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
-import { MenuItemWithLink } from '../../core'
+import { MenuItemWithLink, MenuBadgeItem } from '../../core'
 import VPSidebarLink from './VPSidebarLink.vue'
+import VTMenuBadge from '../../core/components/VTMenuBadge.vue'
 import { isActive } from '../support/utils'
 import { useData } from 'vitepress'
 
 const props = defineProps<{
   text: string
+  badge?: MenuBadgeItem
   items: MenuItemWithLink[]
 }>()
 
@@ -20,7 +22,7 @@ function hasActiveLink() {
   <section class="VPSidebarGroup">
     <div class="title">
       <h2 class="title-text" :class="{ active: hasActiveLink() }">
-        {{ text }}
+        {{ text }}<VTMenuBadge v-if="badge" :item="badge" />
       </h2>
     </div>
 

--- a/src/vitepress/components/VPSidebarLink.vue
+++ b/src/vitepress/components/VPSidebarLink.vue
@@ -2,6 +2,7 @@
 import { useData } from 'vitepress'
 import { ref, inject, onMounted, watchPostEffect } from 'vue'
 import { MenuItemWithLink } from '../../core'
+import VTMenuBadge from '../../core/components/VTMenuBadge.vue'
 import { isActive } from '../support/utils'
 
 const props = defineProps<{
@@ -26,7 +27,9 @@ watchPostEffect(updateActive)
     :href="item.link"
     @click="closeSideBar"
   >
-    <p class="link-text">{{ item.text }}</p>
+    <p class="link-text">
+      {{ item.text }}<VTMenuBadge v-if="item.badge" :item="item.badge" />
+    </p>
   </a>
 </template>
 

--- a/src/vitepress/config.ts
+++ b/src/vitepress/config.ts
@@ -2,6 +2,7 @@ import {
   LocaleLinkItem,
   MenuItemChildWithChildren,
   MenuItemWithLink,
+  MenuBadgeItem,
   SocialLink
 } from '../core'
 
@@ -157,6 +158,7 @@ export type NavItemWithLink = MenuItemWithLink & {
 export interface NavItemWithChildren {
   text?: string
   activeMatch?: string
+  badge?: MenuBadgeItem
   items: (NavItemWithLink | MenuItemChildWithChildren)[]
 }
 
@@ -168,6 +170,7 @@ export interface MultiSidebarConfig {
 
 export interface SidebarGroup {
   text: string
+  badge?: MenuBadgeItem
   items: MenuItemWithLink[]
 }
 


### PR DESCRIPTION
### Option to add badges in navigation and sidebar.

Do you want to highlight a link to a **_new_** page, a link to a **_beta_** feature, or any other purpose?

Now it is possible by adding `badge` property to **nav** or **sidebar** configs

```javascript
 {
    text: 'Sponsor',
    badge: { text: 'beta' },
    link: '/sponsor/'
  }
``` 
Additionally, you can specify the color of the badge
```javascript
 {
    text: 'Sponsor',
    badge: { text: 'beta', type: 'success' }, // available types - 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'danger'
    link: '/sponsor/'
  }
``` 
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/cf2c8ab5-497f-41df-a058-a2981cf6ee2d">
<img width="594" alt="image" src="https://github.com/user-attachments/assets/a1d86755-3126-4f3b-9149-c74b9c4bf82e">

**NOTE: This feature is required to be able to highlight the upcoming "Developers" partner page on vuejs.org website.**
 
<img width="1475" alt="image" src="https://github.com/user-attachments/assets/0f86bb44-1cd8-43e3-a04e-544b8f3f39e3">

