### PR TITLE
fix: search style after docsearch run

### DIFF
--- a/src/vitepress/components/VPNavBarSearch.vue
+++ b/src/vitepress/components/VPNavBarSearch.vue
@@ -235,4 +235,9 @@ function load() {
 .DocSearch-Button:hover .DocSearch-Button-Key {
   color: var(--vt-c-brand-light);
 }
+
+.DocSearch-Button .DocSearch-Button-Key--pressed {
+  box-shadow: none;
+  transform: none;
+}
 </style>


### PR DESCRIPTION
Before:

<img width="135" alt="image" src="https://github.com/user-attachments/assets/63cc934b-1485-4896-b569-d2f21b1d3020">

After:

<img width="141" alt="image" src="https://github.com/user-attachments/assets/9ceea02a-9e7d-469c-8c33-f3fafeb5ed68">
