### PR TITLE
Fix navbar menu when zoomed

### DIFF
--- a/src/core/styles/vt-menu-badge.css
+++ b/src/core/styles/vt-menu-badge.css
@@ -1,5 +1,6 @@
 .vt-menu-badge {
   display: inline-block;
+  align-self: center;
   padding: 3.5px 4px;
   margin-left: 6px;
   font-size: 10px;

--- a/src/vitepress/components/VPNavBarMenuLink.vue
+++ b/src/vitepress/components/VPNavBarMenuLink.vue
@@ -25,23 +25,20 @@ const { page } = useData()
     :badge="item.badge"
     :noIcon="true"
   >
-    <span class="vt-link-text">{{ item.text }}</span>
+    {{ item.text }}
   </VTLink>
 </template>
 
 <style scoped>
 .VPNavBarMenuLink {
-  display: grid;
+  display: flex;
+  align-self: center;
   padding: 0 12px;
   font-size: 13px;
   font-weight: 500;
   color: var(--vt-c-text-1);
   transition: color 0.25s;
   white-space: nowrap;
-}
-
-.VPNavBarMenuLink .vt-link-text {
-  align-self: center;
 }
 
 .VPNavBarMenuLink.active {

--- a/src/vitepress/components/VPNavBarMenuLink.vue
+++ b/src/vitepress/components/VPNavBarMenuLink.vue
@@ -3,7 +3,6 @@ import { VTLink } from '../../core'
 import { useData } from 'vitepress'
 import { isActive } from '../support/utils'
 import { NavItemWithLink } from '../config'
-import { text } from 'stream/consumers'
 
 defineProps<{
   item: NavItemWithLink
@@ -36,7 +35,7 @@ const { page } = useData()
   padding: 0 12px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--vt-c-text-1); 
+  color: var(--vt-c-text-1);
   transition: color 0.25s;
   white-space: nowrap;
 }

--- a/src/vitepress/components/VPNavBarMenuLink.vue
+++ b/src/vitepress/components/VPNavBarMenuLink.vue
@@ -3,6 +3,7 @@ import { VTLink } from '../../core'
 import { useData } from 'vitepress'
 import { isActive } from '../support/utils'
 import { NavItemWithLink } from '../config'
+import { text } from 'stream/consumers'
 
 defineProps<{
   item: NavItemWithLink
@@ -25,20 +26,23 @@ const { page } = useData()
     :badge="item.badge"
     :noIcon="true"
   >
-    {{ item.text }}
+    <span class="vt-link-text">{{ item.text }}</span>
   </VTLink>
 </template>
 
 <style scoped>
 .VPNavBarMenuLink {
-  display: block;
+  display: grid;
   padding: 0 12px;
-  line-height: calc(var(--vt-nav-height) - 1px);
   font-size: 13px;
   font-weight: 500;
-  color: var(--vt-c-text-1);
+  color: var(--vt-c-text-1); 
   transition: color 0.25s;
   white-space: nowrap;
+}
+
+.VPNavBarMenuLink .vt-link-text {
+  align-self: center;
 }
 
 .VPNavBarMenuLink.active {


### PR DESCRIPTION
As a user, sometimes I like zooming in the Vue Docs website to make the text look bigger in a large scale monitor.

When zoom is 150%+, the link items in the NavBar are misplaced. This is because of the line-height calculation being a fixed number. I changed the css in the NavBar Menu link and in the menu badge to fix it.

Before:

[before-vuejs-org.webm](https://github.com/user-attachments/assets/f700a69b-a3a2-431a-bdd3-19363b8295e0)


After:

[after-navbar.webm](https://github.com/user-attachments/assets/49b4ff93-0e72-402c-8a7c-f8166d21f3ef)