### PR TITLE
fix(theme): adjust background color for code blocks in custom containers in dark mode

### DIFF
--- a/src/core/styles/vt-doc-code.css
+++ b/src/core/styles/vt-doc-code.css
@@ -38,6 +38,10 @@
   background-color: var(--vt-c-bg-soft);
 }
 
+.dark .vt-doc .custom-block div[class*='language-'] {
+  background-color: var(--vt-c-black);
+}
+
 @media (min-width: 640px) {
   .vt-doc div[class*='language-'] {
     margin: 28px 0;


### PR DESCRIPTION
fix
https://github.com/vuejs/docs/issues/2764

| before | after |
| -- | -- |
|   <img width="519" alt="スクリーンショット 2025-01-20 22 26 15" src="https://github.com/user-attachments/assets/de4d7e95-359e-4214-b44a-9672e169ee6d" />  |  <img width="513" alt="スクリーンショット 2025-01-20 22 25 22" src="https://github.com/user-attachments/assets/9518beec-61bd-46f6-a68f-fdfa1f1306dc" />  |